### PR TITLE
Mount .env file into docker

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,9 +15,13 @@ services:
     restart: unless-stopped
     environment:
       INSTITUTION: carleton-college
+    volumes:
+      - ./.env:/app/.env
 
   stolaf:
     image: frogpond/ccc-server:HEAD
     restart: unless-stopped
     environment:
       INSTITUTION: stolaf-college
+    volumes:
+      - ./.env:/app/.env


### PR DESCRIPTION
This fixes .env loading on *.api.frogpond.tech, allowing google calendar to work properly (among other things)