### PR TITLE
Namespace graphiql api update

### DIFF
--- a/institutions/carleton-college/v1/index.mjs
+++ b/institutions/carleton-college/v1/index.mjs
@@ -51,6 +51,6 @@ api.get('/spaces/hours', hours)
 // graphql
 api.post('/graphql', koaBody(), graphqlKoa({schema}))
 api.get('/graphql', graphqlKoa({schema}))
-api.get('/graphiql', graphiqlKoa({endpointURL: '/api/v1/graphql'}))
+api.get('/graphiql', graphiqlKoa({endpointURL: '/v1/graphql'}))
 
 export {api as v1}

--- a/institutions/stolaf-college/v1/index.mjs
+++ b/institutions/stolaf-college/v1/index.mjs
@@ -34,6 +34,6 @@ api.get('/spaces/hours', hours)
 // graphql
 api.post('/graphql', koaBody(), graphqlKoa({schema}))
 api.get('/graphql', graphqlKoa({schema}))
-api.get('/graphiql', graphiqlKoa({endpointURL: '/api/v1/graphql'}))
+api.get('/graphiql', graphiqlKoa({endpointURL: '/v1/graphql'}))
 
 export {api as v1}


### PR DESCRIPTION
I noticed the graphiql endpoints were not working, and @hawkrives pointed out there's no longer an `/api` namespace.