### PR TITLE
remove CafeScheduleStatusEnum

### DIFF
--- a/institutions/stolaf-college/v1/graphql/index.mjs
+++ b/institutions/stolaf-college/v1/graphql/index.mjs
@@ -121,7 +121,7 @@ const typeDefs = `
   type CafeSchedule {
     date: DateString
     message: String
-    status: CafeScheduleStatusEnum
+    status: String
     shifts: [CafeScheduleShift]
   }
 
@@ -132,10 +132,6 @@ const typeDefs = `
     message: String
     label: String
     hide: Boolean
-  }
-
-  enum CafeScheduleStatusEnum {
-    open
   }
 
   enum MenuTypeEnum {


### PR DESCRIPTION
I don't think an enum is the right fit for this data?

I'm still tying to figure out where enums go in GraphQL.

(This fixes several of our errors with fetching cafés.)