### PR TITLE
Fix up Reason calendars

### DIFF
--- a/modules/node_modules/@frogpond/ccc-lib/calendar/reason.mjs
+++ b/modules/node_modules/@frogpond/ccc-lib/calendar/reason.mjs
@@ -1,36 +1,137 @@
+/* eslint-disable camelcase */
+
 import {get} from '../http'
-import moment from 'moment'
+import moment from 'moment-timezone'
+import dropWhile from 'lodash/dropWhile'
+import dropRightWhile from 'lodash/dropRightWhile'
+import sortBy from 'lodash/sortBy'
 
-function convertReasonEvents(data, now = moment()) {
-	let events = data.map(event => {
-		const startTime = moment(event.datetime)
-		const endTime = startTime
+const TZ = 'US/Central'
+
+function* expandReasonEvent(event, now = moment()) {
+	let {
+		id,
+		name,
+		contact_username,
+		sponsor,
+		end_date,
+		location,
+		description,
+		datetime: start_date,
+		url,
+		dates,
+		hours,
+		minutes,
+		recurrence,
+	} = event
+
+	let originalStartDate = moment.tz(start_date, TZ)
+
+	if (recurrence === 'daily') {
+		let naturalEndDate = moment.tz(end_date, TZ)
+
+		let thisStartDate = originalStartDate.clone()
+
+		let thisEndDate = thisStartDate
 			.clone()
-			.add(event.hours, 'hours')
-			.add(event.minutes, 'minutes')
+			.add(hours, 'hours')
+			.add(minutes, 'minutes')
 
-		return {
-			startTime,
-			endTime,
-			title: event.name || '',
-			description: event.description || '',
-			location: event.location || '',
-			isOngoing: startTime.isBefore(now, 'day') && endTime.isSameOrAfter(now),
-			metadata: {
-				reasonId: event.id,
-			},
-			config: {
-				startTime: true,
-				endTime: true,
-				subtitle: 'location',
-			},
+		if (naturalEndDate.year() !== 0) {
+			thisEndDate = thisEndDate
+				.clone()
+				.year(naturalEndDate.year())
+				.month(naturalEndDate.month())
+				.date(naturalEndDate.date())
 		}
-	})
 
-	return events.slice(0, 50)
+		let isMidnightStart =
+			thisStartDate.hours() === 0 && thisStartDate.minutes() === 0
+		if (!isMidnightStart && thisEndDate.isBefore(now)) {
+			return
+		}
+
+		yield {
+			id,
+			startTime: thisStartDate.toISOString(),
+			endTime: thisEndDate.toISOString(),
+			contact: contact_username,
+			name,
+			sponsor,
+			location,
+			description,
+			url,
+		}
+		return
+	}
+
+	let todayDate = now.format('YYYY-MM-DD')
+	let futureDate = now
+		.clone()
+		.add(60, 'days')
+		.format('YYYY-MM-DD')
+
+	let filteredDates = dropWhile(dates, d => d < todayDate)
+	filteredDates = dropRightWhile(filteredDates, d => d > futureDate)
+
+	for (let date of filteredDates) {
+		let [y, m, d] = date.split('-')
+
+		let thisStartDate = originalStartDate
+			.clone()
+			.year(parseInt(y, 10))
+			.month(parseInt(m, 10) - 1)
+			.date(parseInt(d, 10))
+
+		let thisEndDate = thisStartDate
+			.clone()
+			.add(hours, 'hours')
+			.add(minutes, 'minutes')
+
+		let isMidnightStart =
+			thisStartDate.hours() === 0 && thisStartDate.minutes() === 0
+		if (!isMidnightStart && thisEndDate.isBefore(now)) {
+			return
+		}
+
+		yield {
+			id,
+			startTime: thisStartDate.toISOString(),
+			endTime: thisEndDate.toISOString(),
+			contact: contact_username,
+			name,
+			sponsor,
+			location,
+			description,
+			url,
+		}
+	}
 }
 
-export async function reasonCalendar(calendarUrl, now=moment()) {
+function convertReasonEvent(event, now = moment()) {
+	let ongoing =
+		moment(event.startTime).isBefore(now, 'day') &&
+		moment(event.endTime).isSameOrAfter(now)
+
+	return {
+		startTime: event.startTime,
+		endTime: event.endTime,
+		title: event.name || '',
+		description: event.description || '',
+		location: event.location || '',
+		isOngoing: ongoing,
+		metadata: {
+			reasonId: event.id,
+		},
+		config: {
+			startTime: true,
+			endTime: true,
+			subtitle: 'location',
+		},
+	}
+}
+
+export async function reasonCalendar(calendarUrl, now = moment()) {
 	let dateParams = {
 		// eslint-disable-next-line camelcase
 		start_date: now.clone().format('YYYY-MM-DD'),
@@ -41,13 +142,21 @@ export async function reasonCalendar(calendarUrl, now=moment()) {
 			.format('YYYY-MM-DD'),
 	}
 
-	let params = Object.assign(
-		{},
-		dateParams,
-		{format: 'json'},
-	)
+	let params = Object.assign({}, dateParams, {format: 'json'})
 
 	let resp = await get(calendarUrl, {json: true, query: params})
 
-	return convertReasonEvents(resp.body)
+	let events = []
+	for (let event of resp.body) {
+		events = [...events, ...Array.from(expandReasonEvent(event, now))]
+	}
+
+	// strip out any events that were filtered out
+	events = events.filter(Boolean)
+
+	// sort the events
+	events = sortBy(events, event => event.startTime)
+
+	// return events
+	return events.map(event => convertReasonEvent(event, now))
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,8 +1,7 @@
 {
   "name": "@frogpond/private",
-  "version": "1.0.0",
-  "lockfileVersion": 1,
   "requires": true,
+  "lockfileVersion": 1,
   "dependencies": {
     "@babel/code-frame": {
       "version": "7.0.0-beta.44",
@@ -2028,6 +2027,14 @@
       "version": "2.22.1",
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.22.1.tgz",
       "integrity": "sha512-shJkRTSebXvsVqk56I+lkb2latjBs8I+pc2TzWc545y2iFnSjm7Wg0QMh+ZWcdSLQyGEau5jI8ocnmkyTgr9YQ=="
+    },
+    "moment-timezone": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.16.tgz",
+      "integrity": "sha512-4d1l92plNNqnMkqI/7boWNVXJvwGL2WyByl1Hxp3h/ao3HZiAqaoQY+6KBkYdiN5QtNDpndq+58ozl8W4GVoNw==",
+      "requires": {
+        "moment": ">= 2.9.0"
+      }
     },
     "mri": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "lodash": "^4.17.10",
     "mem": "^3.0.0",
     "moment": "^2.22.1",
+    "moment-timezone": "^0.5.16",
     "p-map": "^1.2.0"
   },
   "devDependencies": {


### PR DESCRIPTION
I've finally figured out how to handle the Reason calendars!

Some background: I made a PR to Carleton's calendar a while back to add a JSON output option. Which is great and all, but their internal representations are … a bit idiosyncratic. As in, they store a single event that gets repeated, instead of expanding it at retrieval time or something IDK.

Anyway, for the longest time I've had this one event that started in 2015 showing up at the top of the calendar, and I've finally figured out how to handle all this stuff.

"Just" do the expansion myself!

It actually works pretty well. `reasonCalendar` now ends with this chunk:

```js
        let events = []
	for (let event of resp.body) {
		events = [...events, ...Array.from(expandReasonEvent(event, now))]
	}

	// strip out any events that were filtered out
	events = events.filter(Boolean)

	// sort the events
	events = sortBy(events, event => event.startTime)

	// return events
	return events.map(event => convertReasonEvent(event, now))
```

which runs each event through the "event expander", who is in charge of expanding repeating events into actual events; then it filters out any events that ended before `now`, sorts the events, and finally converts the Reason representation into our "normal" event format.

`expandReasonEvent` is where the magic happens, though.

First off, if an event repeats "daily", we handle it specially: we just set the end date to the final repetition, so that the app can say "this event runs from today until March 16th" or whatever. There's some code in there to handle the case where there is no end date, so that we don't set the end date in the year 0. It also won't hide an event for "today" if it started at midnight, since that's a semi-reliable representation of an all-day event here.

If an event has any other repetition type, we take the handy "dates" list that Reason gives us, which is all of the dates that the event repeats on, then we remove all dates < today, and all dates > 60 days in the future. For each remaining date in that list, then, we set the original start "date" (+time) to the new date, add the appropriate number of hours to get the "end time", check if we need to emit this repetition (in case it's already past today), and finally send the occurrence back to the master list.

---

before | after
--- | ---
![telegram-cloud-file-1-804732633-53925-8189757174989472651](https://user-images.githubusercontent.com/464441/39559930-894c3990-4e5f-11e8-8c73-826bcc1fb6f1.jpg) | ![telegram-cloud-file-1-806001255-18830--5838604245481178389](https://user-images.githubusercontent.com/464441/39559937-903ff76e-4e5f-11e8-8d2c-dbbb4ba54502.jpg)

