### PR TITLE
Mark /modules/node_modules as nonvendored

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+/modules/node_modules linguist-vendored=false

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-/modules/node_modules linguist-vendored=false
+/modules/node_modules linguist-vendored=false linguist-generated=false


### PR DESCRIPTION
This may require a bit of fixing if we decide to commit `node_modules` trees in our sub-directories, but I think this is fine as long as we don't commit that.

This syntax teaches `linguist`, which is GitHub's internal language/tree understanding project, which is what chooses annotations and what kind of a file our files are.  If my understanding about Linguist is correct, this _should_ disable diff-collapsing in our "actual codebase."

Should be safe-to-apply, as this is just metadata.