### PR TITLE
Modularize GraphQL schema and add St. Olaf calendar support

### DIFF
--- a/modules/node_modules/@frogpond/ccc-lib/calendar/google.mjs
+++ b/modules/node_modules/@frogpond/ccc-lib/calendar/google.mjs
@@ -7,6 +7,7 @@ function convertGoogleEvents(data, now = moment()) {
 		const endTime = moment(event.end.date || event.end.dateTime)
 
 		return {
+			__type: 'google',
 			startTime,
 			endTime,
 			title: event.summary || '',

--- a/modules/node_modules/@frogpond/ccc-lib/calendar/google.mjs
+++ b/modules/node_modules/@frogpond/ccc-lib/calendar/google.mjs
@@ -7,7 +7,7 @@ function convertGoogleEvents(data, now = moment()) {
 		const endTime = moment(event.end.date || event.end.dateTime)
 
 		return {
-			__type: 'google',
+			dataSource: 'google',
 			startTime,
 			endTime,
 			title: event.summary || '',

--- a/modules/node_modules/@frogpond/ccc-lib/calendar/google.mjs
+++ b/modules/node_modules/@frogpond/ccc-lib/calendar/google.mjs
@@ -24,7 +24,7 @@ function convertGoogleEvents(data, now = moment()) {
 	return events
 }
 
-export async function googleCalendar(calendarId, now=moment()) {
+export async function googleCalendar(calendarId, now = moment()) {
 	let calendarUrl = `https://www.googleapis.com/calendar/v3/calendars/${calendarId}/events`
 
 	let params = {

--- a/modules/node_modules/@frogpond/ccc-lib/calendar/reason.mjs
+++ b/modules/node_modules/@frogpond/ccc-lib/calendar/reason.mjs
@@ -114,7 +114,7 @@ function convertReasonEvent(event, now = moment()) {
 		moment(event.endTime).isSameOrAfter(now)
 
 	return {
-		__type: 'reason',
+		dataSource: 'reason',
 		startTime: event.startTime,
 		endTime: event.endTime,
 		title: event.name || '',

--- a/modules/node_modules/@frogpond/ccc-lib/calendar/reason.mjs
+++ b/modules/node_modules/@frogpond/ccc-lib/calendar/reason.mjs
@@ -30,7 +30,7 @@ function convertReasonEvents(data, now = moment()) {
 	return events.slice(0, 50)
 }
 
-export async function reasonCalendar(calendarUrl, now=moment()) {
+export async function reasonCalendar(calendarUrl, now = moment()) {
 	let dateParams = {
 		// eslint-disable-next-line camelcase
 		start_date: now.clone().format('YYYY-MM-DD'),
@@ -41,11 +41,7 @@ export async function reasonCalendar(calendarUrl, now=moment()) {
 			.format('YYYY-MM-DD'),
 	}
 
-	let params = Object.assign(
-		{},
-		dateParams,
-		{format: 'json'},
-	)
+	let params = Object.assign({}, dateParams, {format: 'json'})
 
 	let resp = await get(calendarUrl, {json: true, query: params})
 

--- a/modules/node_modules/@frogpond/ccc-lib/calendar/reason.mjs
+++ b/modules/node_modules/@frogpond/ccc-lib/calendar/reason.mjs
@@ -10,6 +10,7 @@ function convertReasonEvents(data, now = moment()) {
 			.add(event.minutes, 'minutes')
 
 		return {
+			__type: 'reason',
 			startTime,
 			endTime,
 			title: event.name || '',

--- a/modules/node_modules/@frogpond/ccc-lib/feeds/rss.mjs
+++ b/modules/node_modules/@frogpond/ccc-lib/feeds/rss.mjs
@@ -11,10 +11,14 @@ export async function fetchRssFeed(url, query = {}) {
 }
 
 export function convertRssItemToStory(item) {
-	let authors = Array.from(item.querySelectorAll('dc\\:creator')).map(el => el.textContent)
+	let authors = Array.from(item.querySelectorAll('dc\\:creator')).map(
+		el => el.textContent,
+	)
 	authors = authors.length ? authors : ['Unknown Author']
 
-	let categories = Array.from(item.querySelectorAll('category')).map(el => el.textContent)
+	let categories = Array.from(item.querySelectorAll('category')).map(
+		el => el.textContent,
+	)
 
 	let link = item.querySelector('link')
 	link = link ? link.textContent : null

--- a/modules/node_modules/@frogpond/ccci-carleton-college/v1/convos/index.mjs
+++ b/modules/node_modules/@frogpond/ccci-carleton-college/v1/convos/index.mjs
@@ -8,11 +8,15 @@ const archiveBase =
 	'https://apps.carleton.edu/events/convocations/feeds/media_files?page_id=342645'
 
 function processConvo(event) {
-	let title = JSDOM.fragment(event.querySelector('title').textContent).textContent.trim()
+	let title = JSDOM.fragment(
+		event.querySelector('title').textContent,
+	).textContent.trim()
 
 	let description = event.querySelector('description')
 	description = description
-		? JSDOM.fragment(event.querySelector('description').textContent).textContent.trim()
+		? JSDOM.fragment(
+				event.querySelector('description').textContent,
+		  ).textContent.trim()
 		: ''
 
 	let pubDate = moment(event.querySelector('pubDate').textContent)
@@ -23,9 +27,7 @@ function processConvo(event) {
 				type: enclosure.getAttribute('type')
 					? enclosure.getAttribute('type')
 					: '',
-				url: enclosure.getAttribute('url')
-					? enclosure.getAttribute('url')
-					: '',
+				url: enclosure.getAttribute('url') ? enclosure.getAttribute('url') : '',
 				length: enclosure.getAttribute('length')
 					? enclosure.getAttribute('length')
 					: '',
@@ -38,7 +40,9 @@ function processConvo(event) {
 async function _getArchived() {
 	let resp = await get(archiveBase)
 	let dom = new JSDOM(resp.body, {contentType: 'text/xml'})
-	let convos = Array.from(dom.window.document.querySelectorAll('rss channel item')).map(processConvo)
+	let convos = Array.from(
+		dom.window.document.querySelectorAll('rss channel item'),
+	).map(processConvo)
 	convos = convos.slice(0, 100)
 	return Promise.all(convos)
 }

--- a/modules/node_modules/@frogpond/ccci-carleton-college/v1/gh-pages.mjs
+++ b/modules/node_modules/@frogpond/ccci-carleton-college/v1/gh-pages.mjs
@@ -1,1 +1,2 @@
-export const GH_PAGES = filename => `https://carls-app.github.io/carls/${filename}`
+export const GH_PAGES = filename =>
+	`https://carls-app.github.io/carls/${filename}`

--- a/modules/node_modules/@frogpond/ccci-carleton-college/v1/jobs/index.mjs
+++ b/modules/node_modules/@frogpond/ccci-carleton-college/v1/jobs/index.mjs
@@ -78,7 +78,9 @@ export async function fetchJob(link) {
 async function _getAllJobs() {
 	let resp = await GET_ONE_DAY(jobsUrl)
 	let dom = new JSDOM(resp.body, {contentType: 'text/xml'})
-	let jobLinks = Array.from(dom.window.document.querySelectorAll('rss channel item link')).map(link => link.textContent.trim())
+	let jobLinks = Array.from(
+		dom.window.document.querySelectorAll('rss channel item link'),
+	).map(link => link.textContent.trim())
 	return pMap(jobLinks, fetchJob, {concurrency: 4})
 }
 

--- a/modules/node_modules/@frogpond/ccci-carleton-college/v1/menu/index.mjs
+++ b/modules/node_modules/@frogpond/ccci-carleton-college/v1/menu/index.mjs
@@ -2,15 +2,15 @@ import {get, ONE_DAY, ONE_HOUR} from '@frogpond/ccc-lib'
 import * as bonapp from '@frogpond/ccc-lib/bonapp'
 import mem from 'mem'
 
-const pauseMenuUrl = 'https://stodevx.github.io/AAO-React-Native/pause-menu.json'
+const pauseMenuUrl =
+	'https://stodevx.github.io/AAO-React-Native/pause-menu.json'
 const GET_DAY = mem(get, {maxAge: ONE_DAY})
 export const getPauseMenu = () => GET_DAY(pauseMenuUrl, {json: true})
 
 const getMenu = mem(bonapp.menu, {maxAge: ONE_HOUR})
 const getInfo = mem(bonapp.cafe, {maxAge: ONE_HOUR})
 
-export const getCafe = cafeId =>
-	Promise.all([getMenu(cafeId), getInfo(cafeId)])
+export const getCafe = cafeId => Promise.all([getMenu(cafeId), getInfo(cafeId)])
 
 export async function pauseMenu(ctx) {
 	ctx.body = await getPauseMenu().then(resp => resp.body)

--- a/modules/node_modules/@frogpond/ccci-carleton-college/v1/news/index.mjs
+++ b/modules/node_modules/@frogpond/ccci-carleton-college/v1/news/index.mjs
@@ -5,7 +5,9 @@ import mem from 'mem'
 
 export const cachedRssFeed = mem(fetchRssFeed, {maxAge: ONE_HOUR})
 export const cachedWpJsonFeed = mem(fetchWpJson, {maxAge: ONE_HOUR})
-export const cachedNoonNewsBulletein = mem(noonNewsBulletein, {maxAge: ONE_HOUR * 6})
+export const cachedNoonNewsBulletein = mem(noonNewsBulletein, {
+	maxAge: ONE_HOUR * 6,
+})
 
 export async function nnb(ctx) {
 	ctx.body = await cachedNoonNewsBulletein()

--- a/modules/node_modules/@frogpond/ccci-carleton-college/v1/news/nnb.mjs
+++ b/modules/node_modules/@frogpond/ccci-carleton-college/v1/news/nnb.mjs
@@ -5,10 +5,9 @@ const {groupBy, toPairs} = lodash
 const {JSDOM} = _jsdom
 
 export async function noonNewsBulletein() {
-	let resp = await get(
-		'https://apps.carleton.edu/campact/nnb/show.php3',
-		{query: {style: 'rss'}},
-	)
+	let resp = await get('https://apps.carleton.edu/campact/nnb/show.php3', {
+		query: {style: 'rss'},
+	})
 	let dom = new JSDOM(resp.body, {contentType: 'text/xml'})
 
 	let bulletinEls = [...dom.window.document.querySelectorAll('item')]

--- a/modules/node_modules/@frogpond/ccci-carleton-college/v1/orgs/index.mjs
+++ b/modules/node_modules/@frogpond/ccci-carleton-college/v1/orgs/index.mjs
@@ -6,25 +6,36 @@ const {sortBy, startCase} = lodash
 const {JSDOM} = _jsdom
 
 function domToOrg(orgNode) {
-	let name = orgNode.querySelector('h4').textContent.replace(/ Manage$/, '').trim()
+	let name = orgNode
+		.querySelector('h4')
+		.textContent.replace(/ Manage$/, '')
+		.trim()
 
-	const ids = [...orgNode.querySelectorAll('a[name]')].map(n => n.getAttribute('name'))
+	const ids = [...orgNode.querySelectorAll('a[name]')].map(n =>
+		n.getAttribute('name'),
+	)
 	const id = ids.length ? ids[0] : name
 
-	const description = orgNode.querySelector('.orgDescription').textContent.trim()
+	const description = orgNode
+		.querySelector('.orgDescription')
+		.textContent.trim()
 
 	let contacts = orgNode.querySelector('.contacts')
 	contacts = contacts ? contacts.textContent.trim() : ''
 	contacts = contacts.replace(/^Contact: /, '')
 	contacts = contacts ? contacts.split(', ') : []
 
-	const websiteEls = [...orgNode.querySelectorAll('.site a')].map(n => n.getAttribute('href'))
+	const websiteEls = [...orgNode.querySelectorAll('.site a')].map(n =>
+		n.getAttribute('href'),
+	)
 	let website = websiteEls.length ? websiteEls[0] : ''
 	if (website.length && !/^https?:\/\//.test(website)) {
 		website = `http://${website}`
 	}
 
-	const socialLinks = [...orgNode.querySelectorAll('img > a')].map(n => n.parentNode).map(n => n.getAttribute('href'))
+	const socialLinks = [...orgNode.querySelectorAll('img > a')]
+		.map(n => n.parentNode)
+		.map(n => n.getAttribute('href'))
 
 	return {
 		id,
@@ -42,7 +53,9 @@ async function _getOrgs() {
 	let resp = await get(orgsUrl)
 	let dom = new JSDOM(resp.body)
 
-	const allOrgWrappers = dom.window.document.querySelectorAll('.orgContainer, .careerField')
+	const allOrgWrappers = dom.window.document.querySelectorAll(
+		'.orgContainer, .careerField',
+	)
 	const allOrgs = new Map()
 
 	let currentCategory = null

--- a/modules/node_modules/@frogpond/ccci-carleton-college/v1/transit/index.mjs
+++ b/modules/node_modules/@frogpond/ccci-carleton-college/v1/transit/index.mjs
@@ -13,7 +13,9 @@ export async function bus(ctx) {
 }
 
 export function getModes() {
-	return GET(GH_PAGES('transportation.json'), {json: true}).then(resp => resp.body)
+	return GET(GH_PAGES('transportation.json'), {json: true}).then(
+		resp => resp.body,
+	)
 }
 
 export async function modes(ctx) {

--- a/modules/node_modules/@frogpond/ccci-stolaf-college/v1/calendar/graphql.mjs
+++ b/modules/node_modules/@frogpond/ccci-stolaf-college/v1/calendar/graphql.mjs
@@ -37,7 +37,6 @@ export const Event = `
 		location: String
 		isOngoing: Boolean!
 		config: CalendarEventConfig
-		foobar: String!
 	}
 
 	type ReasonCalendarEvent implements CalendarEvent {
@@ -47,8 +46,8 @@ export const Event = `
 		description: String!
 		location: String
 		isOngoing: Boolean!
-		metadata: ReasonCalendarEventMetadata
 		config: CalendarEventConfig
+		metadata: ReasonCalendarEventMetadata
 	}
 
 	enum NamedCalendarName {

--- a/modules/node_modules/@frogpond/ccci-stolaf-college/v1/calendar/graphql.mjs
+++ b/modules/node_modules/@frogpond/ccci-stolaf-college/v1/calendar/graphql.mjs
@@ -1,0 +1,115 @@
+import flatten from 'lodash/flatten'
+import sortBy from 'lodash/sortBy'
+import * as calendars from './index'
+
+export const Event = `
+	scalar ISOString
+	scalar URL
+
+	type CalendarEventConfig {
+		startTime: Boolean!
+		endTime: Boolean!
+		subtitle: String!
+	}
+
+	type ReasonCalendarEventMetadata {
+		reasonId: ID!
+	}
+
+	"""
+	CalendarEvent
+	"""
+	interface CalendarEvent {
+		startTime: ISOString!
+		endTime: ISOString!
+		title: String!
+		description: String!
+		location: String
+		isOngoing: Boolean!
+		config: CalendarEventConfig
+	}
+
+	type GoogleCalendarEvent implements CalendarEvent {
+		startTime: ISOString!
+		endTime: ISOString!
+		title: String!
+		description: String!
+		location: String
+		isOngoing: Boolean!
+		config: CalendarEventConfig
+		foobar: String!
+	}
+
+	type ReasonCalendarEvent implements CalendarEvent {
+		startTime: ISOString!
+		endTime: ISOString!
+		title: String!
+		description: String!
+		location: String
+		isOngoing: Boolean!
+		metadata: ReasonCalendarEventMetadata
+		config: CalendarEventConfig
+	}
+
+	enum NamedCalendarName {
+		STOLAF
+		OLEVILLE
+		NORTHFIELD
+		KRLX
+		KSTO
+	}
+`
+
+export const QueryExtension = `
+	extend type Query {
+		googleCalendar(calendarId: String!): [GoogleCalendarEvent!]
+		reasonCalendar(calendarUrl: URL!): [ReasonCalendarEvent!]
+		calendar(name: NamedCalendarName!): [CalendarEvent!]
+		calendars(names: [NamedCalendarName!]!): [CalendarEvent!]
+	}
+`
+
+export const typeDefs = [QueryExtension, Event]
+
+export const resolvers = {
+	googleCalendar: (root, args) => calendars.getGoogleCalendar(args.calendarId),
+	reasonCalendar: (root, args) => calendars.getReasonCalendar(args.calendarUrl),
+	calendar: (root, args) => {
+		let ctx = {}
+		return calendars[args.name](ctx).then(() => ctx.body)
+	},
+	calendars: (root, args) => {
+		return Promise.all(
+			args.names.map(n => calendars[n]).map(f => {
+				let ctx = {}
+				return Promise.all([ctx, f(ctx)])
+			}),
+		).then(results => {
+			let events = flatten(results.map(([ctx]) => ctx.body))
+			let sorted = sortBy(events, ev => ev.startTime)
+			return sorted
+		})
+	},
+}
+
+export const resolverMap = {
+	CalendarEvent: {
+		__resolveType(obj) {
+			switch (obj.__type) {
+				case 'reason':
+					return 'ReasonCalendarEvent'
+				case 'google':
+					return 'GoogleCalendarEvent'
+				default:
+					return null
+			}
+		},
+	},
+	NamedCalendarName: {
+		STOLAF: 'stolaf',
+		OLEVILLE: 'oleville',
+		NORTHFIELD: 'northfield',
+		KRLX: 'krlx',
+		KSTO: 'ksto',
+	},
+}

--- a/modules/node_modules/@frogpond/ccci-stolaf-college/v1/calendar/graphql.mjs
+++ b/modules/node_modules/@frogpond/ccci-stolaf-college/v1/calendar/graphql.mjs
@@ -94,7 +94,7 @@ export const resolvers = {
 export const resolverMap = {
 	CalendarEvent: {
 		__resolveType(obj) {
-			switch (obj.__type) {
+			switch (obj.dataSource) {
 				case 'reason':
 					return 'ReasonCalendarEvent'
 				case 'google':

--- a/modules/node_modules/@frogpond/ccci-stolaf-college/v1/departments/graphql.mjs
+++ b/modules/node_modules/@frogpond/ccci-stolaf-college/v1/departments/graphql.mjs
@@ -1,0 +1,31 @@
+import {getDepartments} from './index'
+
+export const Department = `
+	"""
+	Department
+	"""
+	type Department {
+		buildingroom: String,
+		buildingabbr: String,
+		buildingname: String,
+		extension: Int,
+		text: String,
+		headcount: Int,
+		email: String,
+		fax: Int,
+		website: String,
+		name: String,
+	}
+`
+
+export const QueryExtension = `
+	extend type Query {
+		departments: [Department!]
+	}
+`
+
+export const typeDefs = [QueryExtension, Department]
+
+export const resolvers = {
+	departments: () => getDepartments().then(data => data.results),
+}

--- a/modules/node_modules/@frogpond/ccci-stolaf-college/v1/dictionary/graphql.mjs
+++ b/modules/node_modules/@frogpond/ccci-stolaf-college/v1/dictionary/graphql.mjs
@@ -19,12 +19,20 @@ export const QueryExtension = `
 
 export const typeDefs = [QueryExtension, Term]
 
-const renameWordToTerm = pair => ({term: pair.word, definition: pair.definition})
+const renameWordToTerm = pair => ({
+	term: pair.word,
+	definition: pair.definition,
+})
 
 export const resolvers = {
-	dictionary: () => getDictionary().then(results => results.data.map(renameWordToTerm)),
+	dictionary: () =>
+		getDictionary().then(results => results.data.map(renameWordToTerm)),
 	dictionarySearch: (root, args) => {
 		let query = args.query.toLowerCase()
-		return getDictionary().then(results => results.data.map(renameWordToTerm).filter(({term}) => term.toLowerCase().includes(query)))
+		return getDictionary().then(results =>
+			results.data
+				.map(renameWordToTerm)
+				.filter(({term}) => term.toLowerCase().includes(query)),
+		)
 	},
 }

--- a/modules/node_modules/@frogpond/ccci-stolaf-college/v1/dictionary/graphql.mjs
+++ b/modules/node_modules/@frogpond/ccci-stolaf-college/v1/dictionary/graphql.mjs
@@ -1,0 +1,30 @@
+import {getDictionary} from './index'
+
+export const Term = `
+	"""
+	Term
+	"""
+	type Term {
+		term: String
+		definition: String
+	}
+`
+
+export const QueryExtension = `
+	extend type Query {
+		dictionary: [Term!]
+		dictionarySearch(query: String!): [Term!]
+	}
+`
+
+export const typeDefs = [QueryExtension, Term]
+
+const renameWordToTerm = pair => ({term: pair.word, definition: pair.definition})
+
+export const resolvers = {
+	dictionary: () => getDictionary().then(results => results.data.map(renameWordToTerm)),
+	dictionarySearch: (root, args) => {
+		let query = args.query.toLowerCase()
+		return getDictionary().then(results => results.data.map(renameWordToTerm).filter(({term}) => term.toLowerCase().includes(query)))
+	},
+}

--- a/modules/node_modules/@frogpond/ccci-stolaf-college/v1/gh-pages.mjs
+++ b/modules/node_modules/@frogpond/ccci-stolaf-college/v1/gh-pages.mjs
@@ -1,1 +1,2 @@
-export const GH_PAGES = filename => `https://stodevx.github.io/AAO-React-Native/${filename}`
+export const GH_PAGES = filename =>
+	`https://stodevx.github.io/AAO-React-Native/${filename}`

--- a/modules/node_modules/@frogpond/ccci-stolaf-college/v1/graphql/index.mjs
+++ b/modules/node_modules/@frogpond/ccci-stolaf-college/v1/graphql/index.mjs
@@ -1,183 +1,13 @@
-import graphqlTools from 'graphql-tools'
-import {getCafe} from '../menu'
-import {getMajors} from '../majors'
-import {getDepartments} from '../departments'
-import {getDictionary} from '../dictionary'
-const {makeExecutableSchema} = graphqlTools
+import graphql from 'graphql-tools'
+import * as menus from '../menu/graphql'
+import * as majors from '../majors/graphql'
+import * as departments from '../departments/graphql'
+import * as dictionary from '../dictionary/graphql'
+const {makeExecutableSchema} = graphql
 
-// Some fake data
-const books = [
-	{
-		title: "Harry Potter and the Sorcerer's stone",
-		author: 'J.K. Rowling',
-	},
-	{
-		title: 'Jurassic Park',
-		author: 'Michael Crichton',
-	},
-]
-
-// The GraphQL schema in string form
-const typeDefs = `
-	scalar HtmlString
-	scalar TimeString24Hour
-	scalar DateString
-
+const typeDef = `
 	type Query {
-		books: [Book]
-		cafe(id: Int): Cafe
-		cafes(ids: [Int]): [Cafe]
-		dictionary: [Term]
-		departments: [Department]
-		majors: [Major]
-	}
-
-	type CorIcon {
-		id: ID!
-		label: String
-		sort: Int
-	}
-
-	type MenuItem {
-		id: ID!
-		label: String
-		description: String
-		cor: [CorIcon]
-		price: String
-		sizes: [String]
-		nutrition: Nutrition
-		special: Boolean
-		tier: Int
-		rating: String
-		connector: String
-		#options: [Option]
-		station: Station
-		substation: SubStation
-		#monotony: Monotony
-	}
-
-	type Nutrition {
-		kcal: Int
-	}
-
-	#type Option {}
-
-	#type Monotony {}
-
-	type SubStation {
-		id: ID!
-		label: String
-		sort: String
-		items: [MenuItem]
-	}
-
-	type Station {
-		id: ID!
-		sort: String
-		label: String
-		price: String
-		note: String
-		items: [MenuItem]
-	}
-
-	type MenuPart {
-		id: ID!
-		start: String
-		end: String
-		label: String
-		abbreviation: String
-		stations: [Station]
-	}
-
-	type Menu @cacheControl(maxAge: 3600) {
-		menu_id: ID!
-		name: String!
-		date: String!
-		dayparts: [[MenuPart]]
-	}
-
-	"""
-	A café
-	"""
-	type Cafe @cacheControl(maxAge: 3600) {
-		menu: [Menu]
-		name: String
-		address: String
-		city: String
-		state: String
-		zip: String
-		latitude: Float
-		longitude: Float
-		description: HtmlString
-		message: HtmlString
-		eod: TimeString24Hour
-		timezone: String
-		menuType: MenuTypeEnum
-		menuHtml: HtmlString
-		locationDetail: String
-		weeklySchedule: HtmlString
-		schedule: [CafeSchedule]
-	}
-
-	type CafeSchedule {
-		date: DateString
-		message: String
-		status: CafeScheduleStatusEnum
-		shifts: [CafeScheduleShift]
-	}
-
-	type CafeScheduleShift {
-		id: ID!
-		start: TimeString24Hour
-		end: TimeString24Hour
-		message: String
-		label: String
-		hide: Boolean
-	}
-
-	enum CafeScheduleStatusEnum {
-		open
-	}
-
-	enum MenuTypeEnum {
-		dynamic
-	}
-
-	type Book {
-		title: String
-		author: String
-	}
-
-	"""
-	Major
-	"""
-	type Major @cacheControl(maxAge: 86400) {
-		headcount: Int
-		name: String
-	}
-
-	"""
-	Departments
-	"""
-	type Department @cacheControl(maxAge: 86400) {
-		buildingroom: String,
-		buildingabbr: String,
-		buildingname: String,
-		extension: Int,
-		text: String,
-		headcount: Int,
-		email: String,
-		fax: Int,
-		website: String,
-		name: String,
-	}
-
-	"""
-	Term
-	"""
-	type Term {
-		word: String
-		definition: String
+		institution: String
 	}
 
 	#type Mutation {}
@@ -188,67 +18,29 @@ const typeDefs = `
 	}
 `
 
-const coerceCafeDays = day => ({
-	date: day.date,
-	status: day.status,
-	message: day.message,
-	shifts: day.dayparts.map(s => ({
-		id: s.id,
-		message: s.message,
-		label: s.label,
-		start: s.starttime,
-		end: s.endtime,
-		hide: s.hide === '1',
-	})),
-})
-
-const extractCafeInfo = data => {
-	let [cafeMenu, cafeInfo] = data
-	let cafe = cafeInfo.cafe
-	let menu = cafeMenu.days.map(menuDay => {
-		let dayparts = menuDay.cafe.dayparts.map(parts =>
-			parts.map(daypart =>
-				Object.assign({}, daypart, {
-					start: daypart.starttime,
-					end: daypart.endtime,
-					stations: daypart.stations.map(station =>
-						Object.assign({}, station, {
-							items: station.items.map(itemId => cafeMenu.items[itemId]),
-						}),
-					),
-				}),
-			),
-		)
-		return Object.assign({}, menuDay, {dayparts, date: menuDay.date})
-	})
-
-	return Object.assign({}, cafe, {
-		menuType: cafe.menu_type,
-		menuHtml: cafe.menu_html,
-		locationDetail: cafe.location_detail,
-		weeklySchedule: cafe.weekly_schedule,
-		schedule: cafe.days.map(coerceCafeDays),
-		menu: menu,
-	})
-}
-
-// The resolvers
 const resolvers = {
-	Query: {
-		books: () => books,
-		cafe: (root, args) => getCafe(args.id).then(extractCafeInfo),
-		cafes: (root, args) =>
-			Promise.all(args.ids).map(id => getCafe(id).then(extractCafeInfo)),
-		majors: () => getMajors().then(data => data.results),
-		departments: () => getDepartments().then(data => data.results),
-		dictionary: () => getDictionary().then(results => results.data),
-	},
+	institution: () => process.env.INSTITUTION,
 }
 
 // Put together a schema
 const schema = makeExecutableSchema({
-	typeDefs,
-	resolvers,
+	typeDefs: [
+		typeDef,
+		...menus.typeDefs,
+		...majors.typeDefs,
+		...departments.typeDefs,
+		...dictionary.typeDefs,
+	],
+	resolvers: {
+		Query: Object.assign(
+			{},
+			resolvers,
+			menus.resolvers,
+			majors.resolves,
+			departments.resolvers,
+			dictionary.resolvers,
+		)
+	},
 })
 
 export {schema}

--- a/modules/node_modules/@frogpond/ccci-stolaf-college/v1/graphql/index.mjs
+++ b/modules/node_modules/@frogpond/ccci-stolaf-college/v1/graphql/index.mjs
@@ -1,5 +1,6 @@
 import graphql from 'graphql-tools'
 import * as menus from '../menu/graphql'
+import * as calendars from '../calendar/graphql'
 import * as majors from '../majors/graphql'
 import * as departments from '../departments/graphql'
 import * as dictionary from '../dictionary/graphql'
@@ -18,7 +19,7 @@ const typeDef = `
 	}
 `
 
-const resolvers = {
+const baseResolvers = {
 	institution: () => process.env.INSTITUTION,
 }
 
@@ -27,20 +28,30 @@ const schema = makeExecutableSchema({
 	typeDefs: [
 		typeDef,
 		...menus.typeDefs,
+		...calendars.typeDefs,
 		...majors.typeDefs,
 		...departments.typeDefs,
 		...dictionary.typeDefs,
 	],
-	resolvers: {
-		Query: Object.assign(
-			{},
-			resolvers,
-			menus.resolvers,
-			majors.resolves,
-			departments.resolvers,
-			dictionary.resolvers,
-		),
-	},
+	resolvers: Object.assign(
+		{},
+		calendars.resolverMap || {},
+		menus.resolverMap || {},
+		majors.resolverMap || {},
+		departments.resolverMap || {},
+		dictionary.resolverMap || {},
+		{
+			Query: Object.assign(
+				{},
+				baseResolvers,
+				calendars.resolvers,
+				menus.resolvers,
+				majors.resolvers,
+				departments.resolvers,
+				dictionary.resolvers,
+			),
+		},
+	),
 })
 
 export {schema}

--- a/modules/node_modules/@frogpond/ccci-stolaf-college/v1/graphql/index.mjs
+++ b/modules/node_modules/@frogpond/ccci-stolaf-college/v1/graphql/index.mjs
@@ -39,7 +39,7 @@ const schema = makeExecutableSchema({
 			majors.resolves,
 			departments.resolvers,
 			dictionary.resolvers,
-		)
+		),
 	},
 })
 

--- a/modules/node_modules/@frogpond/ccci-stolaf-college/v1/jobs/index.mjs
+++ b/modules/node_modules/@frogpond/ccci-stolaf-college/v1/jobs/index.mjs
@@ -5,7 +5,7 @@ const GET = mem(get, {maxAge: ONE_DAY})
 
 export function getJobs() {
 	let url = 'https://www.stolaf.edu/apps/stuwork/index.cfm'
-	let query = {fuseaction: 'getall', nostructure: '1', }
+	let query = {fuseaction: 'getall', nostructure: '1'}
 	return GET(url, {json: true, query}).then(resp => resp.body)
 }
 

--- a/modules/node_modules/@frogpond/ccci-stolaf-college/v1/majors/graphql.mjs
+++ b/modules/node_modules/@frogpond/ccci-stolaf-college/v1/majors/graphql.mjs
@@ -1,0 +1,23 @@
+import {getMajors} from '../majors'
+
+export const Major = `
+	"""
+	Major
+	"""
+	type Major {
+		headcount: Int
+		name: String
+	}
+`
+
+export const QueryExtension = `
+	extend type Query {
+		majors: [Major!]
+	}
+`
+
+export const typeDefs = [QueryExtension, Major]
+
+export const resolvers = {
+	majors: () => getMajors().then(data => data.results),
+}

--- a/modules/node_modules/@frogpond/ccci-stolaf-college/v1/majors/index.mjs
+++ b/modules/node_modules/@frogpond/ccci-stolaf-college/v1/majors/index.mjs
@@ -5,7 +5,7 @@ const GET = mem(get, {maxAge: ONE_DAY})
 
 export function getMajors() {
 	let url = 'https://www.stolaf.edu/directory/majors'
-	return GET(url, {json: true, query: {format: 'json',}}).then(resp => resp.body)
+	return GET(url, {json: true, query: {format: 'json'}}).then(resp => resp.body)
 }
 
 export async function majors(ctx) {

--- a/modules/node_modules/@frogpond/ccci-stolaf-college/v1/menu/graphql.mjs
+++ b/modules/node_modules/@frogpond/ccci-stolaf-college/v1/menu/graphql.mjs
@@ -1,0 +1,181 @@
+import {getCafe} from './index'
+
+export const MenuItem = `
+	type CorIcon {
+		id: ID!
+		label: String
+		sort: Int
+	}
+
+	type Nutrition {
+		kcal: Int
+	}
+
+	#type Option {}
+
+	#type Monotony {}
+
+	type MenuItem {
+		id: ID!
+		label: String
+		description: String
+		cor: [CorIcon]
+		price: String
+		sizes: [String]
+		nutrition: Nutrition
+		special: Boolean
+		tier: Int
+		rating: String
+		connector: String
+		#options: [Option]
+		station: String
+		substation: String
+		#monotony: Monotony
+	}
+`
+
+export const Cafe = `
+	scalar HtmlString
+	scalar TimeString24Hour
+	scalar DateString
+
+	"""
+	A café
+	"""
+	type Cafe @cacheControl(maxAge: 3600) {
+		menu: [Menu]
+		name: String
+		address: String
+		city: String
+		state: String
+		zip: String
+		latitude: Float
+		longitude: Float
+		description: HtmlString
+		message: HtmlString
+		eod: TimeString24Hour
+		timezone: String
+		menuType: MenuTypeEnum
+		menuHtml: HtmlString
+		locationDetail: String
+		weeklySchedule: HtmlString
+		schedule: [CafeSchedule]
+	}
+
+	type CafeSchedule {
+		date: DateString
+		message: String
+		status: CafeScheduleStatusEnum
+		shifts: [CafeScheduleShift]
+	}
+
+	type CafeScheduleShift {
+		id: ID!
+		start: TimeString24Hour
+		end: TimeString24Hour
+		message: String
+		label: String
+		hide: Boolean
+	}
+
+	enum CafeScheduleStatusEnum {
+		open
+	}
+
+	enum MenuTypeEnum {
+		dynamic
+	}
+`
+
+export const Menu = `
+	type SubStation {
+		id: ID!
+		label: String
+		sort: String
+		items: [MenuItem]
+	}
+
+	type Station {
+		id: ID!
+		sort: String
+		label: String
+		price: String
+		note: String
+		items: [MenuItem]
+	}
+
+	type MenuPart {
+		id: ID!
+		start: String
+		end: String
+		label: String
+		abbreviation: String
+		stations: [Station]
+	}
+
+	type Menu @cacheControl(maxAge: 3600) {
+		menu_id: ID!
+		name: String!
+		date: String!
+		dayparts: [[MenuPart]]
+	}
+`
+
+export const QueryExtension = `
+	extend type Query {
+		cafe(id: Int!): Cafe
+		cafes(ids: [Int!]): [Cafe]
+	}
+`
+
+export const typeDefs = [QueryExtension, Menu, MenuItem, Cafe]
+
+const coerceCafeDays = day => ({
+	date: day.date,
+	status: day.status,
+	message: day.message,
+	shifts: day.dayparts.map(s => ({
+		id: s.id,
+		message: s.message,
+		label: s.label,
+		start: s.starttime,
+		end: s.endtime,
+		hide: s.hide === '1',
+	})),
+})
+
+const extractCafeInfo = data => {
+	let [cafeMenu, cafeInfo] = data
+	let cafe = cafeInfo.cafe
+	let menu = cafeMenu.days.map(menuDay => {
+		let dayparts = menuDay.cafe.dayparts.map(parts =>
+			parts.map(daypart =>
+				Object.assign({}, daypart, {
+					start: daypart.starttime,
+					end: daypart.endtime,
+					stations: daypart.stations.map(station =>
+						Object.assign({}, station, {
+							items: station.items.map(itemId => cafeMenu.items[itemId]),
+						}),
+					),
+				}),
+			),
+		)
+		return Object.assign({}, menuDay, {dayparts, date: menuDay.date})
+	})
+
+	return Object.assign({}, cafe, {
+		menuType: cafe.menu_type,
+		menuHtml: cafe.menu_html,
+		locationDetail: cafe.location_detail,
+		weeklySchedule: cafe.weekly_schedule,
+		schedule: cafe.days.map(coerceCafeDays),
+		menu: menu,
+	})
+}
+
+export const resolvers = {
+	cafe: (root, args) => getCafe(args.id).then(extractCafeInfo),
+	cafes: (root, args) =>
+		Promise.all(args.ids).map(id => getCafe(id).then(extractCafeInfo)),
+}

--- a/modules/node_modules/@frogpond/ccci-stolaf-college/v1/menu/index.mjs
+++ b/modules/node_modules/@frogpond/ccci-stolaf-college/v1/menu/index.mjs
@@ -10,8 +10,7 @@ export const getPauseMenu = () => GET_DAY(pauseMenuUrl, {json: true})
 const getMenu = mem(bonapp.menu, {maxAge: ONE_HOUR})
 const getInfo = mem(bonapp.cafe, {maxAge: ONE_HOUR})
 
-export const getCafe = cafeId =>
-	Promise.all([getMenu(cafeId), getInfo(cafeId)])
+export const getCafe = cafeId => Promise.all([getMenu(cafeId), getInfo(cafeId)])
 
 export async function pauseMenu(ctx) {
 	ctx.body = await getPauseMenu().then(resp => resp.body)

--- a/modules/node_modules/@frogpond/ccci-stolaf-college/v1/orgs/index.mjs
+++ b/modules/node_modules/@frogpond/ccci-stolaf-college/v1/orgs/index.mjs
@@ -12,11 +12,13 @@ export function cleanOrg(org) {
 		.map(c => Object.assign({}, c, {name: c.name.trim()}))
 		.filter(c => c.name.length)
 
-	let contacts = org.contacts.map(c => Object.assign({}, c, {
-		title: c.title.trim(),
-		firstName: c.firstName.trim(),
-		lastName: c.lastName.trim(),
-	}))
+	let contacts = org.contacts.map(c =>
+		Object.assign({}, c, {
+			title: c.title.trim(),
+			firstName: c.firstName.trim(),
+			lastName: c.lastName.trim(),
+		}),
+	)
 
 	let category = org.category.trim()
 	let meetings = org.meetings.trim()
@@ -40,7 +42,7 @@ export function cleanOrg(org) {
 
 async function _getOrgs() {
 	let orgsUrl = 'https://www.stolaf.edu/orgs/list/index.cfm'
-	let query = {'fuseaction':'getall','nostructure':'1'}
+	let query = {fuseaction: 'getall', nostructure: '1'}
 	let resp = await get(orgsUrl, {json: true, query})
 
 	let cleaned = resp.body.map(cleanOrg)

--- a/modules/node_modules/@frogpond/ccci-stolaf-college/v1/transit/index.mjs
+++ b/modules/node_modules/@frogpond/ccci-stolaf-college/v1/transit/index.mjs
@@ -13,7 +13,9 @@ export async function bus(ctx) {
 }
 
 export function getModes() {
-	return GET(GH_PAGES('transportation.json'), {json: true}).then(resp => resp.body)
+	return GET(GH_PAGES('transportation.json'), {json: true}).then(
+		resp => resp.body,
+	)
 }
 
 export async function modes(ctx) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,8 +1,7 @@
 {
   "name": "@frogpond/private",
-  "version": "1.0.0",
-  "lockfileVersion": 1,
   "requires": true,
+  "lockfileVersion": 1,
   "dependencies": {
     "@babel/code-frame": {
       "version": "7.0.0-beta.44",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "scripts": {
     "p": "pretty-quick",
-    "pretty": "prettier --write '*.mjs' 'modules/**/*.mjs'",
+    "pretty": "prettier --with-node-modules --write '*.mjs' 'modules/**/*.mjs'",
     "lint": "eslint --cache '*.mjs' 'modules/**/*.mjs'",
     "start": "node --experimental-modules -r dotenv/config ./modules/node_modules/@frogpond/ccc-server/index.mjs",
     "stolaf": "env INSTITUTION=stolaf-college npm start",


### PR DESCRIPTION
- i also applied prettification
- and i need to merge master into this to get #37 to fix the merge conflicts

---

I followed the information in the ["Modularizing" section of the docs](https://www.apollographql.com/docs/graphql-tools/generate-schema.html#modularizing) to figure out how to split up the GraphQL schema into multiple files.

Follow-up things, once we've gotten more experience with GraphQL:

- export the schema/associated files from the index.mjs files
- [even later] move some parts of the GraphQL stuff into ccc-lib

## Enums, Interfaces, and Unions

### Enums
Define them in the schema:
```gql
enum NamedCalendarName {
  STOLAF
  OLEVILLE
  NORTHFIELD
  KRLX
  KSTO
}
```

and also put a `NamedCalendarName` field on the `export const resolverMap` in that graphql.mjs file, since the `resolverMap` is what is used to determine the actual value of the enum. The keys of the enum are exposed to GraphiQL etc.

**edit:** turns out that if you don't specify your enum values to `resolverMap`, [they'll just be the uppercase strings you gave in the schema](https://github.com/apollographql/graphql-tools/blob/c4c5d91655587b13dd3579c1446e42b5e72132a7/docs/source/scalars.md#internal-values). I'm still using custom strings here for ease of loading the calendar endpoints.

```js
export const resolverMap = {
  NamedCalendarName: {
    STOLAF: 'stolaf',
    OLEVILLE: 'oleville',
    NORTHFIELD: 'northfield',
    KRLX: 'krlx',
    KSTO: 'ksto',
  },
}
```

### Interfaces
```gql
interface CalendarEvent {
  startTime: ISOString!
  endTime: ISOString!
  title: String!
  description: String!
  location: String
  isOngoing: Boolean!
  config: CalendarEventConfig
}

type GoogleCalendarEvent implements CalendarEvent {
  startTime: ISOString!
  endTime: ISOString!
  title: String!
  description: String!
  location: String
  isOngoing: Boolean!
  config: CalendarEventConfig
}

type ReasonCalendarEvent implements CalendarEvent {
  startTime: ISOString!
  endTime: ISOString!
  title: String!
  description: String!
  location: String
  isOngoing: Boolean!
  config: CalendarEventConfig
  metadata: ReasonCalendarEventMetadata
}

extend type Query {
  calendar(name: NamedCalendarName!): [CalendarEvent!]
}
```

You'll notice that a type that implements an interface can have more properties beyond the interface (see `ReasonCalendarEvent`'s `metadata` field.)

You'll have to do a nifty thing in your query to extract that field ([inline fragments](http://graphql.org/learn/queries/#inline-fragments), though, since `calendar` returns `CalendarEvent`:

```gql
query {
  calendars(names: [STOLAF, OLEVILLE]) {
    title
    ... on ReasonCalendarEvent {
      metadata {
        reasonId
      }
    }
  }
}
```

And you'll need to tell GraphQL how to distinguish between the things that implement the interface (I added `__type` manually in `convertGoogleEvent`/`convertReasonEvent`):

```js
export const resolverMap = {
  CalendarEvent: {
    __resolveType(obj) {
      switch (obj.__type) {
        case 'reason':
          return 'ReasonCalendarEvent'
        case 'google':
          return 'GoogleCalendarEvent'
        default:
          return null
      }
    },
  },
}
```

### Unions

They're fairly similar to Interfaces, in that you need to teach GraphQL how to distinguish the cases (with resolverMap), and the syntax is pretty straightforward:

```gql
type A {a: 1}
type B {b: 1}

union MyType = A | B
```

You'll use the `... on X` syntax to distinguish between types in your query, as well:

```gql
query {
  things {
    ... on A {
      a
    }
    ... on B {
      b
    }
  }
}
```

## The Top Level
Named exports are cool:

```js
import * as calendars from '../calendar/graphql'

const schema = makeExecutableSchema({
  typeDefs: [
    typeDef,
    ...menus.typeDefs,
    ...calendars.typeDefs,
    ...majors.typeDefs,
    ...departments.typeDefs,
    ...dictionary.typeDefs,
  ],
  resolvers: Object.assign(
    {},
    calendars.resolverMap || {},
    menus.resolverMap || {},
    majors.resolverMap || {},
    departments.resolverMap || {},
    dictionary.resolverMap || {},
    {
      Query: Object.assign(
        {},
        baseResolvers,
        calendars.resolvers,
        menus.resolvers,
        majors.resolvers,
        departments.resolvers,
        dictionary.resolvers,
      ),
    },
  ),
})
```

## Example

```gql
query {
  calendars(names: [STOLAF, OLEVILLE]) {
    title
    startTime
    endTime
    ... on ReasonCalendarEvent {
      metadata {
        reasonId
      }
    }
  }
  cafes(ids: [34, 35]) {
    name
  }
}
```

```json
{
  "data": {
    "calendars": [
      {
        "title": "Hold Fast: A FYEA Exhibition",
        "startTime": "2018-04-27T05:00:00.000Z",
        "endTime": "2018-05-18T05:00:00.000Z"
      },
      {
        "title": "St. Olaf College Men's Track and Field at  MIAC Combined Events",
        "startTime": "2018-05-03T05:00:00.000Z",
        "endTime": "2018-05-04T05:00:00.000Z"
      },
      {
        "title": "St. Olaf College Women's Track and Field at  MIAC Heptathlon",
        "startTime": "2018-05-03T05:00:00.000Z",
        "endTime": "2018-05-05T05:00:00.000Z"
      },
      {
        "title": "Open to All: Student Senate",
        "startTime": "2018-05-15T23:30:00.000Z",
        "endTime": "2018-05-16T01:30:00.000Z"
      },
      {
        "title": "Paws for Finals",
        "startTime": "2018-05-17T16:00:00.000Z",
        "endTime": "2018-05-17T18:00:00.000Z"
      }
    ],
    "cafes": [
      {
        "name": "Sayles Hill Café"
      },
      {
        "name": "Burton"
      }
    ]
  }
}
```