### PR TITLE
Implement HTML-to-Markdown conversion

### DIFF
--- a/modules/node_modules/@frogpond/ccc-lib/index.mjs
+++ b/modules/node_modules/@frogpond/ccc-lib/index.mjs
@@ -1,2 +1,3 @@
 export {get} from './http'
 export * from './cache'
+export * from './url'

--- a/modules/node_modules/@frogpond/ccc-lib/url.mjs
+++ b/modules/node_modules/@frogpond/ccc-lib/url.mjs
@@ -1,0 +1,23 @@
+import url from 'url'
+import isAbsoluteUrl from 'is-absolute-url'
+import normalizeUrl from 'normalize-url'
+
+function getBaseUrl(urlStr) {
+	// removes everything but the base url
+	let urlObj = url.parse(urlStr)
+	if (!urlObj.hostname && !urlObj.pathname) {
+		throw new Error('Invalid URL')
+	}
+	delete urlObj.pathname
+	delete urlObj.fragment
+	delete urlObj.query
+	return url.format(urlObj)
+}
+
+export function makeAbsoluteUrl(urlStr, {baseUrl} = {}) {
+	if (!isAbsoluteUrl(urlStr)) {
+		baseUrl = getBaseUrl(baseUrl)
+		urlStr = `${baseUrl}${urlStr}`
+	}
+	return normalizeUrl(urlStr, {removeWWW: false, removeHash: false})
+}

--- a/modules/node_modules/@frogpond/ccc-markdown/from-html.mjs
+++ b/modules/node_modules/@frogpond/ccc-markdown/from-html.mjs
@@ -1,14 +1,33 @@
 import Turndown from 'turndown'
+import {makeAbsoluteUrl} from '@frogpond/ccc-lib'
 
-let turndown = new Turndown({
-	hr: '---',
-	bulletListMarker: '-',
-})
+const turndown = (content, {baseUrl = ''} = {}) => {
+	let t = new Turndown({
+		headingStyle: 'atx',
+		hr: '---',
+		bulletListMarker: '-',
+	})
 
-export function fromHtmlString(htmlStr) {
-	return turndown.turndown(htmlStr)
+	t.addRule('absolute-urls', {
+		filter: function(node, options) {
+			return (
+				options.linkStyle === 'inlined' &&
+				node.nodeName === 'A' &&
+				node.getAttribute('href')
+			)
+		},
+
+		replacement: function(content, node) {
+			let href = node.getAttribute('href')
+			href = makeAbsoluteUrl(href, {baseUrl})
+			let title = node.title ? ` "${node.title}"` : ''
+			return `[${content}](${href}${title})`
+		},
+	})
+
+	return t.turndown(content)
 }
 
-export function fromHtmlDom(dom) {
-	return turndown.turndown(dom)
+export function fromHtml(htmlStr, opts) {
+	return turndown(htmlStr, opts)
 }

--- a/modules/node_modules/@frogpond/ccc-markdown/from-html.mjs
+++ b/modules/node_modules/@frogpond/ccc-markdown/from-html.mjs
@@ -1,0 +1,14 @@
+import Turndown from 'turndown'
+
+let turndown = new Turndown({
+	hr: '---',
+	bulletListMarker: '-',
+})
+
+export function fromHtmlString(htmlStr) {
+	return turndown.turndown(htmlStr)
+}
+
+export function fromHtmlDom(dom) {
+	return turndown.turndown(dom)
+}

--- a/modules/node_modules/@frogpond/ccc-markdown/index.mjs
+++ b/modules/node_modules/@frogpond/ccc-markdown/index.mjs
@@ -1,1 +1,1 @@
-export {fromHtmlString, fromHtmlDom} from './from-html'
+export {fromHtml} from './from-html'

--- a/modules/node_modules/@frogpond/ccc-markdown/index.mjs
+++ b/modules/node_modules/@frogpond/ccc-markdown/index.mjs
@@ -1,0 +1,1 @@
+export {fromHtmlString, fromHtmlDom} from './from-html'

--- a/modules/node_modules/@frogpond/ccc-markdown/package.json
+++ b/modules/node_modules/@frogpond/ccc-markdown/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@frogpond/ccc-markdown",
+  "version": "1.0.0"
+}

--- a/modules/node_modules/@frogpond/ccc-server/index.mjs
+++ b/modules/node_modules/@frogpond/ccc-server/index.mjs
@@ -3,6 +3,7 @@ import etag from 'koa-etag'
 import compress from 'koa-compress'
 import logger from 'koa-logger'
 import responseTime from 'koa-response-time'
+import bodyParser from 'koa-bodyparser'
 import Router from 'koa-router'
 import Koa from 'koa'
 
@@ -42,6 +43,8 @@ async function main() {
 	// etag works together with conditional-get
 	app.use(conditional())
 	app.use(etag())
+	// parse request bodies
+	app.use(bodyParser())
 	// hook in the router
 	app.use(router.routes())
 	app.use(router.allowedMethods())

--- a/modules/node_modules/@frogpond/ccci-carleton-college/v1/convos/index.mjs
+++ b/modules/node_modules/@frogpond/ccci-carleton-college/v1/convos/index.mjs
@@ -37,7 +37,7 @@ function processConvo(event) {
 	return {title, description, pubDate, enclosure}
 }
 
-async function _getArchived() {
+async function fetchArchived() {
 	let resp = await get(archiveBase)
 	let dom = new JSDOM(resp.body, {contentType: 'text/xml'})
 	let convos = Array.from(
@@ -47,7 +47,7 @@ async function _getArchived() {
 	return Promise.all(convos)
 }
 
-export const getArchived = mem(_getArchived, {maxAge: ONE_DAY})
+export const getArchived = mem(fetchArchived, {maxAge: ONE_DAY})
 
 export async function archived(ctx) {
 	ctx.body = await getArchived()

--- a/modules/node_modules/@frogpond/ccci-carleton-college/v1/convos/index.mjs
+++ b/modules/node_modules/@frogpond/ccci-carleton-college/v1/convos/index.mjs
@@ -1,4 +1,5 @@
-import {get, ONE_DAY} from '@frogpond/ccc-lib'
+import {get, ONE_DAY, makeAbsoluteUrl} from '@frogpond/ccc-lib'
+import {fromHtml} from '@frogpond/ccc-markdown'
 import mem from 'mem'
 import _jsdom from 'jsdom'
 import moment from 'moment'
@@ -35,6 +36,38 @@ function processConvo(event) {
 		: null
 
 	return {title, description, pubDate, enclosure}
+}
+
+async function fetchUpcoming(eventId) {
+	let baseUrl = 'https://apps.carleton.edu/events/convocations/'
+	let url = 'https://apps.carleton.edu/events/convocations/'
+	let resp = await get(url, {query: {event_id: String(eventId)}})
+
+	let dom = new JSDOM(resp.body)
+
+	let eventEl = dom.window.document.querySelector('.eventItemMain')
+
+	let descEl = eventEl.querySelector('.eventContent')
+	let descText = descEl ? fromHtml(descEl, {baseUrl}) : ''
+
+	let images = [...eventEl.querySelectorAll('.media a')]
+		.map(imgLink => imgLink.getAttribute('href'))
+		.map(href => makeAbsoluteUrl(href, {baseUrl}))
+
+	let sponsor = eventEl.querySelector('.sponsorContactInfo')
+	let sponsorText = sponsor ? fromHtml(sponsor, baseUrl) : ''
+
+	return {
+		images,
+		content: descText,
+		sponsor: sponsorText,
+	}
+}
+
+export const getUpcoming = mem(fetchUpcoming, {maxAge: ONE_DAY})
+
+export async function upcomingDetail(ctx) {
+	ctx.body = await getUpcoming(ctx.params.id)
 }
 
 async function fetchArchived() {

--- a/modules/node_modules/@frogpond/ccci-carleton-college/v1/index.mjs
+++ b/modules/node_modules/@frogpond/ccci-carleton-college/v1/index.mjs
@@ -67,6 +67,7 @@ api.get('/dictionary', dictionary.dictionary)
 
 // convos
 api.get('/convos/upcoming', calendar.convos)
+api.get('/convos/upcoming/:id', convos.upcomingDetail)
 api.get('/convos/archived', convos.archived)
 
 // important contacts

--- a/modules/node_modules/@frogpond/ccci-carleton-college/v1/index.mjs
+++ b/modules/node_modules/@frogpond/ccci-carleton-college/v1/index.mjs
@@ -16,6 +16,7 @@ import * as menus from './menu'
 import * as news from './news'
 import * as orgs from './orgs'
 import * as transit from './transit'
+import * as util from './util'
 import * as webcams from './webcams'
 
 const {graphqlKoa, graphiqlKoa} = apollo
@@ -108,5 +109,8 @@ api.get('/transit/modes', transit.modes)
 api.post('/graphql', koaBody(), graphqlKoa({schema}))
 api.get('/graphql', graphqlKoa({schema}))
 api.get('/graphiql', graphiqlKoa({endpointURL: '/v1/graphql'}))
+
+// utilities
+api.get('/util/html-to-md', util.htmlToMarkdown)
 
 export {api}

--- a/modules/node_modules/@frogpond/ccci-carleton-college/v1/util/index.mjs
+++ b/modules/node_modules/@frogpond/ccci-carleton-college/v1/util/index.mjs
@@ -1,0 +1,5 @@
+import {fromHtml} from '@frogpond/ccc-markdown'
+
+export function htmlToMarkdown(ctx) {
+	ctx.response.body = fromHtml(ctx.request.body.text)
+}

--- a/modules/node_modules/@frogpond/ccci-stolaf-college/v1/index.mjs
+++ b/modules/node_modules/@frogpond/ccci-stolaf-college/v1/index.mjs
@@ -16,6 +16,7 @@ import * as menus from './menu'
 import * as news from './news'
 import * as orgs from './orgs'
 import * as transit from './transit'
+import * as util from './util'
 import * as webcams from './webcams'
 
 const {graphqlKoa, graphiqlKoa} = apollo
@@ -104,5 +105,8 @@ api.get('/transit/modes', transit.modes)
 api.post('/graphql', koaBody(), graphqlKoa({schema}))
 api.get('/graphql', graphqlKoa({schema}))
 api.get('/graphiql', graphiqlKoa({endpointURL: '/v1/graphql'}))
+
+// utilities
+api.get('/util/html-to-md', util.htmlToMarkdown)
 
 export {api}

--- a/modules/node_modules/@frogpond/ccci-stolaf-college/v1/util/index.mjs
+++ b/modules/node_modules/@frogpond/ccci-stolaf-college/v1/util/index.mjs
@@ -1,0 +1,5 @@
+import {fromHtml} from '@frogpond/ccc-markdown'
+
+export function htmlToMarkdown(ctx) {
+	ctx.response.body = fromHtml(ctx.request.body.text)
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -2891,6 +2891,14 @@
         "safe-buffer": "^5.0.1"
       }
     },
+    "turndown": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/turndown/-/turndown-4.0.2.tgz",
+      "integrity": "sha512-pqZ6WrHFGnxXC9q2xJ3Qa7EoLAwrojgFRajWZjxTKwbz9vnNnyi8lLjiD5h86UTPOcMlEyHjm6NMhjEDdlc25A==",
+      "requires": {
+        "jsdom": "^11.9.0"
+      }
+    },
     "tweetnacl": {
       "version": "0.14.5",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -531,9 +531,9 @@
       "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
     },
     "co-body": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/co-body/-/co-body-5.1.1.tgz",
-      "integrity": "sha1-2XeB0eM0S6SoIP0YBr3fg0FQUjY=",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/co-body/-/co-body-5.2.0.tgz",
+      "integrity": "sha512-sX/LQ7LqUhgyaxzbe7IqwPeTr2yfpfUIQ/dgpKo6ZI4y4lpQA0YxAomWIY+7I7rHWcG02PG+OuPREzMW/5tszQ==",
       "requires": {
         "inflation": "^2.0.0",
         "qs": "^6.4.0",
@@ -1524,6 +1524,11 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-1.0.3.tgz",
       "integrity": "sha1-3FiQdvZZ9BnCIgOaMzFvHHOH7/0="
+    },
+    "is-absolute-url": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-absolute-url/-/is-absolute-url-2.1.0.tgz",
+      "integrity": "sha1-UFMN+4T8yap9vnhS6Do3uTufKqY="
     },
     "is-fullwidth-code-point": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "graphql": "^0.13.2",
     "graphql-tools": "^2.23.1",
     "html-entities": "^1.2.1",
+    "is-absolute-url": "^2.1.0",
     "jsdom": "^11.10.0",
     "koa": "^2.5.0",
     "koa-bodyparser": "^4.2.0",
@@ -44,6 +45,7 @@
     "mem": "^3.0.0",
     "moment": "^2.22.1",
     "moment-timezone": "^0.5.16",
+    "normalize-url": "^2.0.1",
     "p-map": "^1.2.0",
     "turndown": "^4.0.2"
   },

--- a/package.json
+++ b/package.json
@@ -44,7 +44,8 @@
     "mem": "^3.0.0",
     "moment": "^2.22.1",
     "moment-timezone": "^0.5.16",
-    "p-map": "^1.2.0"
+    "p-map": "^1.2.0",
+    "turndown": "^4.0.2"
   },
   "devDependencies": {
     "babel-eslint": "^8.2.3",


### PR DESCRIPTION
- `[stolaf]` `[carleton]` Adds `/v1/util/html-to-md` endpoints that allow you to `GET` with a request body `{text: "foo"}` and get back that text, processed as HTML, converted to Markdown
- `[carleton]` Adds `/v1/convos/upcoming/:id` to fetch the details of an upcoming convocation, and get back the `{content, images, sponsor}` that CARLS expects.

`turndown`, the library I pulled in to handle the markdown conversion, was chosen in large part because it relies on JSDOM to do the HTML parsing, instead of `htmlparser2` (or worse, rolling its own parser). I couldn't use it before because I can't use [I think] JSDOM on the client side.

---

This PR is paired with https://github.com/carls-app/carls/pull/215