### PR TITLE
Add default nginx server

### DIFF
--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -77,7 +77,7 @@ server {
 
   listen 443 ssl http2;
   listen [::]:443 ssl http2;
-  access_log /var/log/nginx/access.log vhost;
+  access_log /var/log/nginx/carleton.access.log vhost;
 
   # "Mozilla-Modern" cipher suite
   ssl_protocols TLSv1.2;
@@ -115,7 +115,7 @@ server {
 
   listen 443 ssl http2;
   listen [::]:443 ssl http2;
-  access_log /var/log/nginx/access.log vhost;
+  access_log /var/log/nginx/stolaf.access.log vhost;
 
   # "Mozilla-Intermediate" cipher suite
   ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
@@ -134,4 +134,38 @@ server {
   ssl_trusted_certificate /etc/letsencrypt/live/api.frogpond.tech/fullchain.pem;
 
   add_header Strict-Transport-Security "max-age=2419200; includeSubDomains" always;
+}
+
+server {
+  listen 80 default_server;
+  listen [::]:80 default_server;
+
+  listen 443 ssl http2 default_server;
+  listen [::]:443 ssl http2 default_server;
+  access_log /var/log/nginx/default.access.log vhost;
+
+  server_name _; # This is just an invalid value which will never trigger on a real hostname.
+  server_name_in_redirect off;
+
+  # "Mozilla-Modern" cipher suite
+  ssl_protocols TLSv1.2;
+  ssl_ciphers 'ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256';
+
+  ssl_prefer_server_ciphers on;
+  ssl_session_timeout 5m;
+  ssl_session_cache shared:SSL:50m;
+  ssl_session_tickets off;
+
+  ssl_certificate /etc/letsencrypt/live/api.frogpond.tech/fullchain.pem;
+  ssl_certificate_key /etc/letsencrypt/live/api.frogpond.tech/privkey.pem;
+
+  ssl_stapling on;
+  ssl_stapling_verify on;
+  ssl_trusted_certificate /etc/letsencrypt/live/api.frogpond.tech/fullchain.pem;
+
+  add_header Strict-Transport-Security "max-age=2419200; includeSubDomains" always;
+
+  location ~ / {
+    deny all;
+  }
 }


### PR DESCRIPTION
This catches any requests to api.frogpond.tech, instead of them going to `carleton.` or `stolaf.`

Kris is sitting next to me as I do this.