### PR TITLE
Change most one-day carleton caches to one-day

### DIFF
--- a/modules/node_modules/@frogpond/ccci-carleton-college/v1/contacts/index.mjs
+++ b/modules/node_modules/@frogpond/ccci-carleton-college/v1/contacts/index.mjs
@@ -2,7 +2,7 @@ import {get, ONE_HOUR} from '@frogpond/ccc-lib'
 import mem from 'mem'
 import {GH_PAGES} from '../gh-pages'
 
-const GET = mem(get, {maxAge: ONE_HOUR * 6})
+const GET = mem(get, {maxAge: ONE_HOUR})
 
 let url = GH_PAGES('contact-info.json')
 

--- a/modules/node_modules/@frogpond/ccci-carleton-college/v1/contacts/index.mjs
+++ b/modules/node_modules/@frogpond/ccci-carleton-college/v1/contacts/index.mjs
@@ -1,8 +1,8 @@
-import {get, ONE_DAY} from '@frogpond/ccc-lib'
+import {get, ONE_HOUR} from '@frogpond/ccc-lib'
 import mem from 'mem'
 import {GH_PAGES} from '../gh-pages'
 
-const GET = mem(get, {maxAge: ONE_DAY})
+const GET = mem(get, {maxAge: ONE_HOUR * 6})
 
 let url = GH_PAGES('contact-info.json')
 

--- a/modules/node_modules/@frogpond/ccci-carleton-college/v1/convos/index.mjs
+++ b/modules/node_modules/@frogpond/ccci-carleton-college/v1/convos/index.mjs
@@ -1,4 +1,4 @@
-import {get, ONE_DAY, makeAbsoluteUrl} from '@frogpond/ccc-lib'
+import {get, ONE_HOUR, makeAbsoluteUrl} from '@frogpond/ccc-lib'
 import {fromHtml} from '@frogpond/ccc-markdown'
 import mem from 'mem'
 import _jsdom from 'jsdom'
@@ -64,7 +64,7 @@ async function fetchUpcoming(eventId) {
 	}
 }
 
-export const getUpcoming = mem(fetchUpcoming, {maxAge: ONE_DAY})
+export const getUpcoming = mem(fetchUpcoming, {maxAge: ONE_HOUR * 6})
 
 export async function upcomingDetail(ctx) {
 	ctx.body = await getUpcoming(ctx.params.id)
@@ -80,7 +80,7 @@ async function fetchArchived() {
 	return Promise.all(convos)
 }
 
-export const getArchived = mem(fetchArchived, {maxAge: ONE_DAY})
+export const getArchived = mem(fetchArchived, {maxAge: ONE_HOUR * 6})
 
 export async function archived(ctx) {
 	ctx.body = await getArchived()

--- a/modules/node_modules/@frogpond/ccci-carleton-college/v1/dictionary/index.mjs
+++ b/modules/node_modules/@frogpond/ccci-carleton-college/v1/dictionary/index.mjs
@@ -1,8 +1,8 @@
-import {get, ONE_DAY} from '@frogpond/ccc-lib'
+import {get, ONE_HOUR} from '@frogpond/ccc-lib'
 import mem from 'mem'
 import {GH_PAGES} from '../gh-pages'
 
-const GET = mem(get, {maxAge: ONE_DAY})
+const GET = mem(get, {maxAge: ONE_HOUR * 6})
 
 let url = GH_PAGES('dictionary-carls.json')
 

--- a/modules/node_modules/@frogpond/ccci-carleton-college/v1/dictionary/index.mjs
+++ b/modules/node_modules/@frogpond/ccci-carleton-college/v1/dictionary/index.mjs
@@ -2,7 +2,7 @@ import {get, ONE_HOUR} from '@frogpond/ccc-lib'
 import mem from 'mem'
 import {GH_PAGES} from '../gh-pages'
 
-const GET = mem(get, {maxAge: ONE_HOUR * 6})
+const GET = mem(get, {maxAge: ONE_HOUR})
 
 let url = GH_PAGES('dictionary-carls.json')
 

--- a/modules/node_modules/@frogpond/ccci-carleton-college/v1/faqs/index.mjs
+++ b/modules/node_modules/@frogpond/ccci-carleton-college/v1/faqs/index.mjs
@@ -1,8 +1,8 @@
-import {get, ONE_DAY} from '@frogpond/ccc-lib'
+import {get, ONE_HOUR} from '@frogpond/ccc-lib'
 import mem from 'mem'
 import {GH_PAGES} from '../gh-pages'
 
-const GET = mem(get, {maxAge: ONE_DAY})
+const GET = mem(get, {maxAge: ONE_HOUR * 6})
 
 let url = GH_PAGES('faqs.json')
 

--- a/modules/node_modules/@frogpond/ccci-carleton-college/v1/faqs/index.mjs
+++ b/modules/node_modules/@frogpond/ccci-carleton-college/v1/faqs/index.mjs
@@ -2,7 +2,7 @@ import {get, ONE_HOUR} from '@frogpond/ccc-lib'
 import mem from 'mem'
 import {GH_PAGES} from '../gh-pages'
 
-const GET = mem(get, {maxAge: ONE_HOUR * 6})
+const GET = mem(get, {maxAge: ONE_HOUR})
 
 let url = GH_PAGES('faqs.json')
 

--- a/modules/node_modules/@frogpond/ccci-carleton-college/v1/help/index.mjs
+++ b/modules/node_modules/@frogpond/ccci-carleton-college/v1/help/index.mjs
@@ -2,7 +2,7 @@ import {get, ONE_HOUR} from '@frogpond/ccc-lib'
 import mem from 'mem'
 import {GH_PAGES} from '../gh-pages'
 
-const GET = mem(get, {maxAge: ONE_HOUR * 6})
+const GET = mem(get, {maxAge: ONE_HOUR})
 
 let url = GH_PAGES('help.json')
 

--- a/modules/node_modules/@frogpond/ccci-carleton-college/v1/help/index.mjs
+++ b/modules/node_modules/@frogpond/ccci-carleton-college/v1/help/index.mjs
@@ -1,8 +1,8 @@
-import {get, ONE_DAY} from '@frogpond/ccc-lib'
+import {get, ONE_HOUR} from '@frogpond/ccc-lib'
 import mem from 'mem'
 import {GH_PAGES} from '../gh-pages'
 
-const GET = mem(get, {maxAge: ONE_DAY})
+const GET = mem(get, {maxAge: ONE_HOUR * 6})
 
 let url = GH_PAGES('help.json')
 

--- a/modules/node_modules/@frogpond/ccci-carleton-college/v1/hours/index.mjs
+++ b/modules/node_modules/@frogpond/ccci-carleton-college/v1/hours/index.mjs
@@ -2,7 +2,7 @@ import {get, ONE_HOUR} from '@frogpond/ccc-lib'
 import mem from 'mem'
 import {GH_PAGES} from '../gh-pages'
 
-const GET = mem(get, {maxAge: ONE_HOUR * 6})
+const GET = mem(get, {maxAge: ONE_HOUR})
 
 let url = GH_PAGES('building-hours.json')
 

--- a/modules/node_modules/@frogpond/ccci-carleton-college/v1/hours/index.mjs
+++ b/modules/node_modules/@frogpond/ccci-carleton-college/v1/hours/index.mjs
@@ -1,8 +1,8 @@
-import {get, ONE_DAY} from '@frogpond/ccc-lib'
+import {get, ONE_HOUR} from '@frogpond/ccc-lib'
 import mem from 'mem'
 import {GH_PAGES} from '../gh-pages'
 
-const GET = mem(get, {maxAge: ONE_DAY})
+const GET = mem(get, {maxAge: ONE_HOUR * 6})
 
 let url = GH_PAGES('building-hours.json')
 

--- a/modules/node_modules/@frogpond/ccci-carleton-college/v1/map/index.mjs
+++ b/modules/node_modules/@frogpond/ccci-carleton-college/v1/map/index.mjs
@@ -1,7 +1,7 @@
-import {get, ONE_DAY} from '@frogpond/ccc-lib'
+import {get, ONE_HOUR} from '@frogpond/ccc-lib'
 import mem from 'mem'
 
-const GET = mem(get, {maxAge: ONE_DAY})
+const GET = mem(get, {maxAge: ONE_HOUR * 6})
 
 let url = 'https://carls-app.github.io/map-data/'
 

--- a/modules/node_modules/@frogpond/ccci-carleton-college/v1/map/index.mjs
+++ b/modules/node_modules/@frogpond/ccci-carleton-college/v1/map/index.mjs
@@ -1,7 +1,7 @@
 import {get, ONE_HOUR} from '@frogpond/ccc-lib'
 import mem from 'mem'
 
-const GET = mem(get, {maxAge: ONE_HOUR * 6})
+const GET = mem(get, {maxAge: ONE_HOUR})
 
 let url = 'https://carls-app.github.io/map-data/'
 

--- a/modules/node_modules/@frogpond/ccci-carleton-college/v1/menu/index.mjs
+++ b/modules/node_modules/@frogpond/ccci-carleton-college/v1/menu/index.mjs
@@ -1,11 +1,11 @@
-import {get, ONE_DAY, ONE_HOUR} from '@frogpond/ccc-lib'
+import {get, ONE_HOUR} from '@frogpond/ccc-lib'
 import * as bonapp from '@frogpond/ccc-lib/bonapp'
 import mem from 'mem'
 
 const pauseMenuUrl =
 	'https://stodevx.github.io/AAO-React-Native/pause-menu.json'
-const GET_DAY = mem(get, {maxAge: ONE_DAY})
-export const getPauseMenu = () => GET_DAY(pauseMenuUrl, {json: true})
+const GET_LONG = mem(get, {maxAge: ONE_HOUR * 6})
+export const getPauseMenu = () => GET_LONG(pauseMenuUrl, {json: true})
 
 const getMenu = mem(bonapp.menu, {maxAge: ONE_HOUR})
 const getInfo = mem(bonapp.cafe, {maxAge: ONE_HOUR})

--- a/modules/node_modules/@frogpond/ccci-carleton-college/v1/menu/index.mjs
+++ b/modules/node_modules/@frogpond/ccci-carleton-college/v1/menu/index.mjs
@@ -4,7 +4,7 @@ import mem from 'mem'
 
 const pauseMenuUrl =
 	'https://stodevx.github.io/AAO-React-Native/pause-menu.json'
-const GET_LONG = mem(get, {maxAge: ONE_HOUR * 6})
+const GET_LONG = mem(get, {maxAge: ONE_HOUR})
 export const getPauseMenu = () => GET_LONG(pauseMenuUrl, {json: true})
 
 const getMenu = mem(bonapp.menu, {maxAge: ONE_HOUR})

--- a/modules/node_modules/@frogpond/ccci-carleton-college/v1/transit/index.mjs
+++ b/modules/node_modules/@frogpond/ccci-carleton-college/v1/transit/index.mjs
@@ -2,7 +2,7 @@ import {get, ONE_HOUR} from '@frogpond/ccc-lib'
 import mem from 'mem'
 import {GH_PAGES} from '../gh-pages'
 
-const GET = mem(get, {maxAge: ONE_HOUR * 6})
+const GET = mem(get, {maxAge: ONE_HOUR})
 
 export function getBus() {
 	return GET(GH_PAGES('bus-times.json'), {json: true}).then(resp => resp.body)

--- a/modules/node_modules/@frogpond/ccci-carleton-college/v1/transit/index.mjs
+++ b/modules/node_modules/@frogpond/ccci-carleton-college/v1/transit/index.mjs
@@ -1,8 +1,8 @@
-import {get, ONE_DAY} from '@frogpond/ccc-lib'
+import {get, ONE_HOUR} from '@frogpond/ccc-lib'
 import mem from 'mem'
 import {GH_PAGES} from '../gh-pages'
 
-const GET = mem(get, {maxAge: ONE_DAY})
+const GET = mem(get, {maxAge: ONE_HOUR * 6})
 
 export function getBus() {
 	return GET(GH_PAGES('bus-times.json'), {json: true}).then(resp => resp.body)

--- a/modules/node_modules/@frogpond/ccci-carleton-college/v1/webcams/index.mjs
+++ b/modules/node_modules/@frogpond/ccci-carleton-college/v1/webcams/index.mjs
@@ -2,7 +2,7 @@ import {get, ONE_HOUR} from '@frogpond/ccc-lib'
 import mem from 'mem'
 import {GH_PAGES} from '../gh-pages'
 
-const GET = mem(get, {maxAge: ONE_HOUR * 6})
+const GET = mem(get, {maxAge: ONE_HOUR})
 
 let url = GH_PAGES('webcams.json')
 

--- a/modules/node_modules/@frogpond/ccci-carleton-college/v1/webcams/index.mjs
+++ b/modules/node_modules/@frogpond/ccci-carleton-college/v1/webcams/index.mjs
@@ -1,8 +1,8 @@
-import {get, ONE_DAY} from '@frogpond/ccc-lib'
+import {get, ONE_HOUR} from '@frogpond/ccc-lib'
 import mem from 'mem'
 import {GH_PAGES} from '../gh-pages'
 
-const GET = mem(get, {maxAge: ONE_DAY})
+const GET = mem(get, {maxAge: ONE_HOUR * 6})
 
 let url = GH_PAGES('webcams.json')
 


### PR DESCRIPTION
I keep merging PRs on CARLS because I feel a need to get them out, since they're just data updates, but they're cached for 24 hours, so if I don't get them out ASAP they'll not be updated for another day…

~~but with this, I know they'll be updated four times a day.~~

actually, I've decided I'd prefer one hour timeouts here.

thoughts?

we can deploy this whenever, tomorrow, although it's probably best to do so in the early morning so as to minimize disruption.

part of #50 