### PR TITLE
Trim wp-json-based news excerpt and title fields

### DIFF
--- a/modules/node_modules/@frogpond/ccc-lib/feeds/wp-json.mjs
+++ b/modules/node_modules/@frogpond/ccc-lib/feeds/wp-json.mjs
@@ -40,9 +40,9 @@ export function convertWpJsonItemToStory(item) {
 		categories: [],
 		content: item.content.rendered,
 		datePublished: item.date_gmt,
-		excerpt: JSDOM.fragment(item.excerpt.rendered).textContent,
+		excerpt: JSDOM.fragment(item.excerpt.rendered).textContent.trim(),
 		featuredImage: featuredImage,
 		link: item.link,
-		title: JSDOM.fragment(item.title.rendered).textContent,
+		title: JSDOM.fragment(item.title.rendered).textContent.trim(),
 	}
 }


### PR DESCRIPTION
closes #55 

The RSS-based feeds are already trimmed (see [modules/node_modules/@frogpond/ccc-lib/feeds/rss.mjs#L28](https://github.com/frog-pond/ccc-server/blob/2f9acb110a8968ef30b6a433ca25172ace9288f4/modules/node_modules/%40frogpond/ccc-lib/feeds/rss.mjs#L28) and [modules/node_modules/@frogpond/ccc-lib/feeds/rss.mjs#L43](https://github.com/frog-pond/ccc-server/blob/2f9acb110a8968ef30b6a433ca25172ace9288f4/modules/node_modules/%40frogpond/ccc-lib/feeds/rss.mjs#L43)).