### PR TITLE
Avoid compressing the Docker image cache

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,20 +18,20 @@ x-config:
     - &cache-save-docker
       key: docker--{{ arch }}-{{ .Branch }}-{{ .Revision }}
       paths:
-        - /tmp/image.tar.gz
+        - /tmp/image.tar
     - &cmd-docker-load
       name: 'Load from cache if possible'
       command: |
-        if test -r /tmp/image.tar.gz; then
-          echo "Loading from /tmp/image.tar.gz"
-          docker load -qi /tmp/image.tar.gz
+        if test -r /tmp/image.tar; then
+          echo "Loading from /tmp/image.tar"
+          docker load -qi /tmp/image.tar
         else
-          echo "missing /tmp/image.tar.gz; failing the build"
+          echo "missing /tmp/image.tar; failing the build"
           exit 1
         fi
     - &cmd-docker-save
-      name: 'Dump image to cachable .tar.gz file'
-      command: docker save "$LOCAL_NAME:$CIRCLE_SHA1" | pigz -9c > /tmp/image.tar.gz
+      name: 'Dump image to cachable .tar file'
+      command: docker save "$LOCAL_NAME:$CIRCLE_SHA1" > /tmp/image.tar
 
 workflows:
   version: 2
@@ -87,7 +87,6 @@ jobs:
       - run:
           name: Build docker image
           command: docker build --cache-from="$(docker images -a -q)" -t "$LOCAL_NAME:$CIRCLE_SHA1" .
-      - run: sudo apt install -y pigz
       - run: *cmd-docker-save
       - save_cache: *cache-save-docker
 


### PR DESCRIPTION
This is not really necessary. Compressing our Docker images once built may help us shave off perhaps a few bytes of network transfer, but assuming that network speed is no factor simply increases the build time by adding complexity.

Also, since our Docker image is small in the first place, installing the `pigz` package for _every_ build is much slower than… not doing that.

This PR adjusts all commands to instead cache to just /tmp/image.tar.

Closes #61.