### PR TITLE
Remove filtering, grouping logic from streams

### DIFF
--- a/modules/node_modules/@frogpond/ccci-stolaf-college/v1/streams/index.mjs
+++ b/modules/node_modules/@frogpond/ccci-stolaf-college/v1/streams/index.mjs
@@ -1,9 +1,6 @@
 import {get, ONE_DAY} from '@frogpond/ccc-lib'
 import mem from 'mem'
 import moment from 'moment'
-import titleCase from 'titlecase'
-import toPairs from 'lodash/toPairs'
-import groupBy from 'lodash/groupBy'
 
 const GET = mem(get, {maxAge: ONE_DAY})
 
@@ -21,29 +18,7 @@ export async function getStreams(streamClass, dateFrom, dateTo) {
 	const data = await GET(url, {json: true, query: params}).then(
 		resp => resp.body,
 	)
-	const streams = data.results
-
-	// force title-case on the stream types, to prevent not-actually-duplicate headings
-	const processed = streams
-		.map(stream => {
-			const date = moment(stream.starttime, 'YYYY-MM-DD HH:mm')
-			const group =
-				stream.status && stream.status.toLowerCase() !== 'live'
-					? date.format('dddd, MMMM Do')
-					: 'Live'
-
-			return {
-				...stream,
-				category: titleCase.toLaxTitleCase(stream.category),
-				date: date,
-				$groupBy: group,
-			}
-		})
-
-	const grouped = groupBy(processed, j => j.$groupBy)
-	const mapped = toPairs(grouped).map(([title, data]) => ({title, data}))
-
-	return mapped
+	return data
 }
 
 export async function upcoming(ctx) {


### PR DESCRIPTION
Removing the grouping and filtering that I offloaded onto the server. This should be a client-side operation as not everything will _want_ grouped and filtered data. This will return the requested fetch instead.