### PR TITLE
Stop using --experimental-modules and switch to -r esm

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -977,6 +977,11 @@
       "integrity": "sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ==",
       "dev": true
     },
+    "esm": {
+      "version": "3.0.77",
+      "resolved": "https://registry.npmjs.org/esm/-/esm-3.0.77.tgz",
+      "integrity": "sha512-5BKqPeWKJBulw1hVamb6rDmbL3NXUPYSKha83NEw9/4Mm0gs0YdXexd99kKsEuU7QFCFM4i83++eU+AOPCgjmA=="
+    },
     "espree": {
       "version": "3.5.4",
       "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.4.tgz",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "p": "pretty-quick",
     "pretty": "prettier --with-node-modules --write '*.mjs' 'modules/**/*.mjs'",
     "lint": "eslint --cache '*.mjs' 'modules/**/*.mjs'",
-    "start": "node --experimental-modules -r dotenv/config ./modules/node_modules/@frogpond/ccc-server/index.mjs",
+    "start": "node -r esm -r dotenv/config ./modules/node_modules/@frogpond/ccc-server/index.mjs",
     "stolaf": "env INSTITUTION=stolaf-college npm start",
     "carleton": "env INSTITUTION=carleton-college npm start",
     "test": "echo \"Error: no test specified\""
@@ -25,6 +25,7 @@
   "dependencies": {
     "apollo-server-koa": "^1.3.4",
     "dotenv": "^5.0.1",
+    "esm": "^3.0.77",
     "get-urls": "^7.2.0",
     "got": "^8.3.0",
     "graphql": "^0.13.2",


### PR DESCRIPTION
Like it says in the title.

The `esm` package is partially maintained by the same guy who maintains Lodash, plus it's less likely to break randomly than something labelled `--experimental`.