### PR TITLE
Add new endpoint for color printers list

### DIFF
--- a/modules/node_modules/@frogpond/ccci-stolaf-college/v1/index.mjs
+++ b/modules/node_modules/@frogpond/ccci-stolaf-college/v1/index.mjs
@@ -15,6 +15,7 @@ import * as majors from './majors'
 import * as menus from './menu'
 import * as news from './news'
 import * as orgs from './orgs'
+import * as printing from './printing'
 import * as streams from './streams'
 import * as transit from './transit'
 import * as util from './util'
@@ -105,6 +106,9 @@ api.get('/transit/modes', transit.modes)
 // streams
 api.get('/streams/archived', streams.archived)
 api.get('/streams/upcoming', streams.upcoming)
+
+// stoprint
+api.get('/printing/color-printers', printing.colorPrinters)
 
 // graphql
 api.post('/graphql', koaBody(), graphqlKoa({schema}))

--- a/modules/node_modules/@frogpond/ccci-stolaf-college/v1/printing/index.mjs
+++ b/modules/node_modules/@frogpond/ccci-stolaf-college/v1/printing/index.mjs
@@ -1,0 +1,15 @@
+import {get, ONE_DAY} from '@frogpond/ccc-lib'
+import mem from 'mem'
+import {GH_PAGES} from '../gh-pages'
+
+const GET = mem(get, {maxAge: ONE_DAY})
+
+let url = GH_PAGES('color-printers.json')
+
+export function getColorPrinters() {
+	return GET(url, {json: true}).then(resp => resp.body)
+}
+
+export async function colorPrinters(ctx) {
+	ctx.body = await getColorPrinters()
+}


### PR DESCRIPTION
~~WIP with an as-yet unreleased PR in StoDevX/AllAboutOlaf~~

Proxies the data source added in https://github.com/StoDevX/AAO-React-Native/pull/2839

```
~ ⚘ curl https://stodevx.github.io/AAO-React-Native/color-printers.json
{"data":{"colorPrinters":["mfc-rml-4-disco","mfc-toh101"]}}
```