### PR TITLE
Politicole endpoint swap

### DIFF
--- a/modules/node_modules/@frogpond/ccci-stolaf-college/v1/news/index.mjs
+++ b/modules/node_modules/@frogpond/ccci-stolaf-college/v1/news/index.mjs
@@ -27,7 +27,7 @@ export async function oleville(ctx) {
 }
 
 export async function politicole(ctx) {
-	let url = 'https://www.oleville.com/politicole/wp-json/wp/v2/posts/'
+	let url = 'https://oleville.com/politicole/wp-json/wp/v2/posts/'
 	ctx.body = await cachedWpJsonFeed(url, {per_page: 10, _embed: true})
 }
 

--- a/modules/node_modules/@frogpond/ccci-stolaf-college/v1/news/index.mjs
+++ b/modules/node_modules/@frogpond/ccci-stolaf-college/v1/news/index.mjs
@@ -27,8 +27,8 @@ export async function oleville(ctx) {
 }
 
 export async function politicole(ctx) {
-	let url = 'https://oleville.com/politicole/feed/'
-	ctx.body = await cachedRssFeed(url)
+	let url = 'https://www.oleville.com/politicole/wp-json/wp/v2/posts/'
+	ctx.body = await cachedWpJsonFeed(url, {per_page: 10, _embed: true})
 }
 
 export async function mess(ctx) {


### PR DESCRIPTION
Let's use the `wp-json` endpoint instead of the `rss` one.

Before | After
--|--
<img width="436" alt="old" src="https://user-images.githubusercontent.com/5240843/44425221-7a20d300-a548-11e8-8bae-1044bf8524f8.png"> | <img width="436" alt="new" src="https://user-images.githubusercontent.com/5240843/44425223-7ab96980-a548-11e8-9526-ad414b9d3343.png">