### PR TITLE
Deduplicate Student Orgs members lists

### DIFF
--- a/modules/node_modules/@frogpond/ccci-carleton-college/v1/orgs/index.mjs
+++ b/modules/node_modules/@frogpond/ccci-carleton-college/v1/orgs/index.mjs
@@ -24,6 +24,7 @@ function domToOrg(orgNode) {
 	contacts = contacts ? contacts.textContent.trim() : ''
 	contacts = contacts.replace(/^Contact: /, '')
 	contacts = contacts ? contacts.split(', ') : []
+	contacts = [...new Set(contacts)]
 
 	const websiteEls = [...orgNode.querySelectorAll('.site a')].map(n =>
 		n.getAttribute('href'),


### PR DESCRIPTION
Example: Bridge Club

before: 
```
"contacts": [
            "Thomas Scruggs",
            "Allie Clark",
            "Alina Maki",
            "Alina Maki",
            "Erica Helgerud",
            "Erica Helgerud",
            "Thomas Scruggs"
        ],
```

after:
```
"contacts": [
            "Thomas Scruggs",
            "Allie Clark",
            "Alina Maki",
            "Erica Helgerud"
        ],
```