### PR TITLE
expand the env.INSTITUTION check to catch more cases

### DIFF
--- a/modules/node_modules/@frogpond/ccc-server/index.mjs
+++ b/modules/node_modules/@frogpond/ccc-server/index.mjs
@@ -9,7 +9,7 @@ import Koa from 'koa'
 
 async function main() {
 	const institution = process.env.INSTITUTION
-	if (institution === 'unknown') {
+	if (!institution || institution === 'unknown') {
 		console.error(
 			'please add -e INSTITUTION=$place to your docker run, or set the environment variable in some way',
 		)


### PR DESCRIPTION
I've got some code to warn you if you forget to set the INSTITUTION variable, but it didn't cover the most common case – just running `npm start`, so there's no environment variable at all.

This PR fixes that oversight.