### PR TITLE
Add admin link to org type

### DIFF
--- a/modules/node_modules/@frogpond/ccci-carleton-college/v1/orgs/index.mjs
+++ b/modules/node_modules/@frogpond/ccci-carleton-college/v1/orgs/index.mjs
@@ -11,6 +11,9 @@ function domToOrg(orgNode) {
 		.textContent.replace(/ Manage$/, '')
 		.trim()
 
+	let adminLink = orgNode.querySelector('h4 > a').href
+	adminLink = `https://apps.carleton.edu${adminLink}`
+
 	const ids = [...orgNode.querySelectorAll('a[name]')].map(n =>
 		n.getAttribute('name'),
 	)
@@ -46,6 +49,7 @@ function domToOrg(orgNode) {
 		website,
 		categories: [],
 		socialLinks,
+		adminLink,
 	}
 }
 


### PR DESCRIPTION
To be used in CARLS to power a button to let org leaders quickly open the editing webpage.