### PR TITLE
Shorten St. Olaf hours maxAge to 1 hr

### DIFF
--- a/modules/node_modules/@frogpond/ccci-stolaf-college/v1/hours/index.mjs
+++ b/modules/node_modules/@frogpond/ccci-stolaf-college/v1/hours/index.mjs
@@ -2,7 +2,7 @@ import {get, ONE_DAY} from '@frogpond/ccc-lib'
 import mem from 'mem'
 import {GH_PAGES} from '../gh-pages'
 
-const GET = mem(get, {maxAge: ONE_DAY})
+const GET = mem(get, {maxAge: ONE_HOUR})
 
 let url = GH_PAGES('building-hours.json')
 

--- a/modules/node_modules/@frogpond/ccci-stolaf-college/v1/hours/index.mjs
+++ b/modules/node_modules/@frogpond/ccci-stolaf-college/v1/hours/index.mjs
@@ -1,4 +1,4 @@
-import {get, ONE_DAY} from '@frogpond/ccc-lib'
+import {get, ONE_HOUR} from '@frogpond/ccc-lib'
 import mem from 'mem'
 import {GH_PAGES} from '../gh-pages'
 


### PR DESCRIPTION
This brings things into parity with Carleton's hours cache expiry.

I can't think of a reason to have a longer time, to be honest. This data is more ephemeral than we would like it to be, and since this request is going out to a CDN, it doesn't really matter that we're repeating it more often.