### PR TITLE
Move event link extraction to the server

### DIFF
--- a/modules/node_modules/@frogpond/ccc-google-calendar/index.mjs
+++ b/modules/node_modules/@frogpond/ccc-google-calendar/index.mjs
@@ -1,5 +1,6 @@
 import {get} from '@frogpond/ccc-lib'
 import moment from 'moment'
+import getUrls from 'get-urls'
 import _jsdom from 'jsdom'
 const {JSDOM} = _jsdom
 
@@ -18,6 +19,7 @@ function convertGoogleEvents(data, now = moment()) {
 			description: description,
 			location: event.location || '',
 			isOngoing: startTime.isBefore(now, 'day'),
+			links: [...getUrls(description)],
 			config: {
 				startTime: true,
 				endTime: true,

--- a/modules/node_modules/@frogpond/ccc-reason-calendar/index.mjs
+++ b/modules/node_modules/@frogpond/ccc-reason-calendar/index.mjs
@@ -5,6 +5,7 @@ import moment from 'moment-timezone'
 import dropWhile from 'lodash/dropWhile'
 import dropRightWhile from 'lodash/dropRightWhile'
 import sortBy from 'lodash/sortBy'
+import getUrls from 'get-urls'
 
 const TZ = 'US/Central'
 
@@ -120,6 +121,7 @@ function convertReasonEvent(event, now = moment()) {
 		title: event.name || '',
 		description: event.description || '',
 		location: event.location || '',
+		links: event.description ? [...getUrls(event.description)] : [],
 		isOngoing: ongoing,
 		metadata: {
 			reasonId: event.id,


### PR DESCRIPTION
This allows us to remove get-urls from AAO entirely, along with the associated monkey-patching.