### PR TITLE
Use port 80

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,12 +9,12 @@ ADD ./package-lock.json /app
 RUN npm install --production
 
 HEALTHCHECK --interval=20s --timeout=1s \
-  CMD curl -f http://localhost:3001/ping
+  CMD curl -f http://localhost:80/ping
 
 ADD . /app
 
 ENV NODE_ENV=production
-ENV NODE_PORT=3001
+ENV NODE_PORT=80
 ENV INSTITUTION=unknown
 
 CMD node --experimental-modules -r dotenv/config ./modules/node_modules/@frogpond/ccc-server/index.mjs

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -62,7 +62,7 @@ proxy_set_header X-Forwarded-Port $proxy_x_forwarded_port;
 
 # carleton.api.frogpond.tech
 upstream carleton.api.frogpond.tech {
-  server carleton:3001;
+  server carleton:80;
 }
 
 server {
@@ -86,7 +86,7 @@ server {
 
 # stolaf.api.frogpond.tech
 upstream stolaf.api.frogpond.tech {
-  server stolaf:3001;
+  server stolaf:80;
 }
 
 server {


### PR DESCRIPTION
Yep.

Node should have no problem binding to a privileged port, especially if it's in a container where it has root privileges.

Commentary from 911ca90:
>All of the reading I have done (fairly limited) seems to suggest that it is a good idea to set the container up as if it were its own dedicated server and not to do any monkey business.  Setting to a non-standard HTTP server port (3001) is what I would consider monkey business.