### PR TITLE
streams: Use moment.tz() instead of moment()

### DIFF
--- a/modules/node_modules/@frogpond/ccci-stolaf-college/v1/streams/index.mjs
+++ b/modules/node_modules/@frogpond/ccci-stolaf-college/v1/streams/index.mjs
@@ -22,11 +22,9 @@ export async function getStreams({streamClass, sort, dateFrom, dateTo}) {
 		let {starttime} = stream
 		return {
 			...stream,
-			starttime: moment(
-				starttime,
-				"YYYY-MM-DD HH:mm",
-				"America/Chicago"
-			).toISOString(),
+			starttime: moment
+				.tz(starttime, 'YYYY-MM-DD HH:mm', 'America/Chicago')
+				.toISOString(),
 		}
 	})
 


### PR DESCRIPTION
The distinction here being that:

> The `moment.tz` constructor takes all the same arguments as the `moment` constructor, but uses the last argument as a time zone identifier.

(See https://momentjs.com/timezone/docs/#/using-timezones/parsing-in-zone/)

This commit resolves #85 again, by instead invoking the moment.tz constructor. I verified that we have `moment-timezone` installed and tested this. While the streams that get fetched are still different depending on which time zone the server is in, I have resolved the issue in question.