### PR TITLE
streams: Render date{To,From} in America/Chicago

### DIFF
--- a/modules/node_modules/@frogpond/ccci-stolaf-college/v1/streams/index.mjs
+++ b/modules/node_modules/@frogpond/ccci-stolaf-college/v1/streams/index.mjs
@@ -33,9 +33,12 @@ export async function getStreams({streamClass, sort, dateFrom, dateTo}) {
 
 export async function upcoming(ctx) {
 	const {
-		dateFrom = moment().format('YYYY-MM-DD'),
+		dateFrom = moment()
+			.tz('America/Chicago')
+			.format('YYYY-MM-DD'),
 		dateTo = moment()
 			.add(2, 'month')
+			.tz('America/Chicago')
 			.format('YYYY-MM-DD'),
 		sort = 'ascending',
 	} = ctx.query
@@ -50,9 +53,12 @@ export async function upcoming(ctx) {
 
 export async function archived(ctx) {
 	const {
-		dateTo = moment().format('YYYY-MM-DD'),
 		dateFrom = moment()
 			.subtract(2, 'month')
+			.tz('America/Chicago')
+			.format('YYYY-MM-DD'),
+		dateTo = moment()
+			.tz('America/Chicago')
 			.format('YYYY-MM-DD'),
 		sort = 'ascending',
 	} = ctx.query


### PR DESCRIPTION
This takes care of any translation necessary, and ensures that no matter where the server is in the world, we will get consistent results.

As long as moment-timezone knows our time zone, it also knows the offset required to convert this to America/Chicago.  Thus, we interact with the BMS API in times that are understood as being in CDT.  In
order to guarantee consistency, we generate moments and do our math *first*, before converting to America/Chicago and then formatting. This commit therefore resolves #89, because I can't find any other places we interact with the BMS API.