### PR TITLE
package.json: Remove main and references to top-level mjs files

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,6 @@
   "name": "@frogpond/private",
   "description": "",
   "repository": "frog-pond/ccc-server",
-  "main": "index.mjs",
   "keywords": [],
   "author": "Frog Pond Labs, LLC",
   "license": "AGPL-3.0-only",
@@ -15,8 +14,8 @@
   },
   "scripts": {
     "p": "pretty-quick",
-    "pretty": "prettier --with-node-modules --write '*.mjs' 'modules/**/*.mjs'",
-    "lint": "eslint --cache '*.mjs' 'modules/**/*.mjs'",
+    "pretty": "prettier --with-node-modules --write 'modules/**/*.mjs'",
+    "lint": "eslint --cache 'modules/**/*.mjs'",
     "start": "node -r esm -r dotenv/config ./modules/node_modules/@frogpond/ccc-server/index.mjs",
     "stolaf": "env INSTITUTION=stolaf-college npm start",
     "carleton": "env INSTITUTION=carleton-college npm start",


### PR DESCRIPTION
None of these things exist, and eslint v5.7 will complain about them not existing.