### PR TITLE
Change renovate's prHourlyLimit to 6

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -10,6 +10,7 @@
   "labels": [
     "renovate"
   ],
+  "prHourlyLimit": 6,
   "packageRules": [
     {
       "packagePatterns": ["^moment"],


### PR DESCRIPTION
allowing Renovate to file three times as many updates per hour