### PR TITLE
renovate: Use prConcurrentLimit instead of prHourlyLimit

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -10,7 +10,7 @@
   "labels": [
     "renovate"
   ],
-  "prHourlyLimit": 6,
+  "prConcurrentLimit": 6,
   "packageRules": [
     {
       "packagePatterns": ["^moment"],

--- a/renovate.json
+++ b/renovate.json
@@ -11,6 +11,7 @@
     "renovate"
   ],
   "prConcurrentLimit": 6,
+  "prHourlyLimit": 0,
   "packageRules": [
     {
       "packagePatterns": ["^moment"],


### PR DESCRIPTION
I don't really see a need for an hourly limit. Maybe there was a reason, but if not, can we use this instead?