### PR TITLE
Add Cache-control headers

### DIFF
--- a/modules/node_modules/@frogpond/ccc-server/index.js
+++ b/modules/node_modules/@frogpond/ccc-server/index.js
@@ -4,6 +4,7 @@ import compress from 'koa-compress'
 import logger from 'koa-logger'
 import responseTime from 'koa-response-time'
 import bodyParser from 'koa-bodyparser'
+import cacheControl from 'koa-ctx-cache-control'
 import Router from 'koa-router'
 import Koa from 'koa'
 
@@ -43,6 +44,8 @@ async function main() {
 	// etag works together with conditional-get
 	app.use(conditional())
 	app.use(etag())
+	// support adding cache-control headers
+	cacheControl(app)
 	// parse request bodies
 	app.use(bodyParser())
 	// hook in the router

--- a/modules/node_modules/@frogpond/ccci-carleton-college/v1/calendar/index.js
+++ b/modules/node_modules/@frogpond/ccci-carleton-college/v1/calendar/index.js
@@ -9,59 +9,83 @@ export const getReasonCalendar = mem(reasonCalendar, {maxAge: ONE_MINUTE})
 export const getEmsCalendar = mem(emsCalendar, {maxAge: ONE_HOUR})
 
 export async function google(ctx) {
+	ctx.cacheControl(ONE_MINUTE)
+
 	let {id: calendarId} = ctx.query
 	ctx.body = await getGoogleCalendar(calendarId)
 }
 
 export async function reason(ctx) {
+	ctx.cacheControl(ONE_MINUTE)
+
 	let {url: calendarUrl} = ctx.query
 	ctx.body = await getReasonCalendar(calendarUrl)
 }
 
 export async function ics(ctx) {
+	ctx.cacheControl(ONE_MINUTE)
+
 	ctx.throw(501, 'ICS support is not implemented yet.')
 }
 
 export async function carleton(ctx) {
+	ctx.cacheControl(ONE_MINUTE)
+
 	let url = 'https://apps.carleton.edu/calendar/'
 	ctx.body = await getReasonCalendar(url)
 }
 
 export async function ems(ctx) {
+	ctx.cacheControl(ONE_HOUR)
+
 	ctx.body = await getEmsCalendar()
 }
 
 export async function cave(ctx) {
+	ctx.cacheControl(ONE_MINUTE)
+
 	let url = 'https://apps.carleton.edu/student/orgs/cave/calendar/'
 	ctx.body = await getReasonCalendar(url)
 }
 
 export async function stolaf(ctx) {
+	ctx.cacheControl(ONE_MINUTE)
+
 	let id = '5g91il39n0sv4c2bjdv1jrvcpq4ulm4r@import.calendar.google.com'
 	ctx.body = await getGoogleCalendar(id)
 }
 
 export async function northfield(ctx) {
+	ctx.cacheControl(ONE_MINUTE)
+
 	let id = 'thisisnorthfield@gmail.com'
 	ctx.body = await getGoogleCalendar(id)
 }
 
 export async function krlx(ctx) {
+	ctx.cacheControl(ONE_MINUTE)
+
 	let id = 'krlxradio88.1@gmail.com'
 	ctx.body = await getGoogleCalendar(id)
 }
 
 export async function ksto(ctx) {
+	ctx.cacheControl(ONE_MINUTE)
+
 	let id = 'kstonarwhal@gmail.com'
 	ctx.body = await getGoogleCalendar(id)
 }
 
 export async function convos(ctx) {
+	ctx.cacheControl(ONE_MINUTE)
+
 	let url = 'https://apps.carleton.edu/events/convocations/'
 	ctx.body = await getReasonCalendar(url)
 }
 
 export async function sumo(ctx) {
+	ctx.cacheControl(ONE_MINUTE)
+
 	let url = 'https://apps.carleton.edu/student/orgs/sumo/'
 	ctx.body = await getReasonCalendar(url)
 }

--- a/modules/node_modules/@frogpond/ccci-carleton-college/v1/contacts/index.js
+++ b/modules/node_modules/@frogpond/ccci-carleton-college/v1/contacts/index.js
@@ -11,5 +11,7 @@ export function getContacts() {
 }
 
 export async function contacts(ctx) {
+	ctx.cacheControl(ONE_HOUR)
+
 	ctx.body = await getContacts()
 }

--- a/modules/node_modules/@frogpond/ccci-carleton-college/v1/convos/index.js
+++ b/modules/node_modules/@frogpond/ccci-carleton-college/v1/convos/index.js
@@ -67,6 +67,8 @@ async function fetchUpcoming(eventId) {
 export const getUpcoming = mem(fetchUpcoming, {maxAge: ONE_HOUR * 6})
 
 export async function upcomingDetail(ctx) {
+	ctx.cacheControl(ONE_HOUR * 6)
+
 	ctx.body = await getUpcoming(ctx.params.id)
 }
 
@@ -83,5 +85,6 @@ async function fetchArchived() {
 export const getArchived = mem(fetchArchived, {maxAge: ONE_HOUR * 6})
 
 export async function archived(ctx) {
+	ctx.cacheControl(ONE_HOUR * 6)
 	ctx.body = await getArchived()
 }

--- a/modules/node_modules/@frogpond/ccci-carleton-college/v1/dictionary/index.js
+++ b/modules/node_modules/@frogpond/ccci-carleton-college/v1/dictionary/index.js
@@ -11,5 +11,7 @@ export function getDictionary() {
 }
 
 export async function dictionary(ctx) {
+	ctx.cacheControl(ONE_HOUR)
+
 	ctx.body = await getDictionary()
 }

--- a/modules/node_modules/@frogpond/ccci-carleton-college/v1/faqs/index.js
+++ b/modules/node_modules/@frogpond/ccci-carleton-college/v1/faqs/index.js
@@ -11,5 +11,7 @@ export function getFaqs() {
 }
 
 export async function faqs(ctx) {
+	ctx.cacheControl(ONE_HOUR)
+
 	ctx.body = await getFaqs()
 }

--- a/modules/node_modules/@frogpond/ccci-carleton-college/v1/help/index.js
+++ b/modules/node_modules/@frogpond/ccci-carleton-college/v1/help/index.js
@@ -11,5 +11,7 @@ export function getHelp() {
 }
 
 export async function help(ctx) {
+	ctx.cacheControl(ONE_HOUR)
+
 	ctx.body = await getHelp()
 }

--- a/modules/node_modules/@frogpond/ccci-carleton-college/v1/hours/index.js
+++ b/modules/node_modules/@frogpond/ccci-carleton-college/v1/hours/index.js
@@ -11,5 +11,7 @@ export function getBuildingHours() {
 }
 
 export async function buildingHours(ctx) {
+	ctx.cacheControl(ONE_HOUR)
+
 	ctx.body = await getBuildingHours()
 }

--- a/modules/node_modules/@frogpond/ccci-carleton-college/v1/jobs/index.js
+++ b/modules/node_modules/@frogpond/ccci-carleton-college/v1/jobs/index.js
@@ -87,5 +87,7 @@ async function _getAllJobs() {
 export const getJobs = mem(_getAllJobs, {maxAge: ONE_HOUR})
 
 export async function jobs(ctx) {
+	ctx.cacheControl(ONE_HOUR)
+
 	ctx.body = await getJobs()
 }

--- a/modules/node_modules/@frogpond/ccci-carleton-college/v1/map/index.js
+++ b/modules/node_modules/@frogpond/ccci-carleton-college/v1/map/index.js
@@ -10,6 +10,8 @@ export function getMap() {
 }
 
 export async function map(ctx) {
+	ctx.cacheControl(ONE_HOUR)
+
 	ctx.body = await getMap()
 }
 
@@ -18,5 +20,7 @@ export function getGeojsonMap() {
 }
 
 export async function geojson(ctx) {
+	ctx.cacheControl(ONE_HOUR)
+
 	ctx.body = await getGeojsonMap()
 }

--- a/modules/node_modules/@frogpond/ccci-carleton-college/v1/menu/index.js
+++ b/modules/node_modules/@frogpond/ccci-carleton-college/v1/menu/index.js
@@ -14,18 +14,26 @@ const getNutrition = mem(bonapp.nutrition, {maxAge: ONE_HOUR})
 export const getCafe = cafeId => Promise.all([getMenu(cafeId), getInfo(cafeId)])
 
 export async function pauseMenu(ctx) {
+	ctx.cacheControl(ONE_HOUR)
+
 	ctx.body = await getPauseMenu().then(resp => resp.body)
 }
 
 export async function bonAppMenu(ctx) {
+	ctx.cacheControl(ONE_HOUR)
+
 	ctx.body = await getMenu(ctx.params.cafeId)
 }
 
 export async function bonAppCafe(ctx) {
+	ctx.cacheControl(ONE_HOUR)
+
 	ctx.body = await getInfo(ctx.params.cafeId)
 }
 
 export async function bonAppNutrition(ctx) {
+	ctx.cacheControl(ONE_HOUR)
+
 	ctx.body = await getNutrition(ctx.params.itemId)
 }
 
@@ -40,57 +48,85 @@ let cafeIds = {
 }
 
 export async function stavCafe(ctx) {
+	ctx.cacheControl(ONE_HOUR)
+
 	ctx.body = await getInfo(cafeIds.stav)
 }
 
 export async function stavMenu(ctx) {
+	ctx.cacheControl(ONE_HOUR)
+
 	ctx.body = await getMenu(cafeIds.stav)
 }
 
 export async function cageCafe(ctx) {
+	ctx.cacheControl(ONE_HOUR)
+
 	ctx.body = await getInfo(cafeIds.cage)
 }
 
 export async function cageMenu(ctx) {
+	ctx.cacheControl(ONE_HOUR)
+
 	ctx.body = await getMenu(cafeIds.cage)
 }
 
 export async function kingsRoomCafe(ctx) {
+	ctx.cacheControl(ONE_HOUR)
+
 	ctx.body = await getInfo(cafeIds.kingsRoom)
 }
 
 export async function kingsRoomMenu(ctx) {
+	ctx.cacheControl(ONE_HOUR)
+
 	ctx.body = await getMenu(cafeIds.kingsRoom)
 }
 
 export async function burtonCafe(ctx) {
+	ctx.cacheControl(ONE_HOUR)
+
 	ctx.body = await getInfo(cafeIds.burton)
 }
 
 export async function burtonMenu(ctx) {
+	ctx.cacheControl(ONE_HOUR)
+
 	ctx.body = await getMenu(cafeIds.burton)
 }
 
 export async function ldcCafe(ctx) {
+	ctx.cacheControl(ONE_HOUR)
+
 	ctx.body = await getInfo(cafeIds.ldc)
 }
 
 export async function ldcMenu(ctx) {
+	ctx.cacheControl(ONE_HOUR)
+
 	ctx.body = await getMenu(cafeIds.ldc)
 }
 
 export async function saylesCafe(ctx) {
+	ctx.cacheControl(ONE_HOUR)
+
 	ctx.body = await getInfo(cafeIds.sayles)
 }
 
 export async function saylesMenu(ctx) {
+	ctx.cacheControl(ONE_HOUR)
+
 	ctx.body = await getMenu(cafeIds.sayles)
 }
 
 export async function weitzCafe(ctx) {
+	ctx.cacheControl(ONE_HOUR)
+
 	ctx.body = await getInfo(cafeIds.weitz)
 }
 
 export async function weitzMenu(ctx) {
+	ctx.cacheControl(ONE_HOUR)
+
 	ctx.body = await getMenu(cafeIds.weitz)
 }

--- a/modules/node_modules/@frogpond/ccci-carleton-college/v1/news/index.js
+++ b/modules/node_modules/@frogpond/ccci-carleton-college/v1/news/index.js
@@ -11,26 +11,38 @@ export const cachedNoonNewsBulletein = mem(noonNewsBulletein, {
 })
 
 export async function nnb(ctx) {
+	ctx.cacheControl(ONE_HOUR * 6)
+
 	ctx.body = await cachedNoonNewsBulletein()
 }
 
 export async function rss(ctx) {
+	ctx.cacheControl(ONE_HOUR)
+
 	ctx.body = await cachedRssFeed(ctx.query.url)
 }
 
 export async function wpJson(ctx) {
+	ctx.cacheControl(ONE_HOUR)
+
 	ctx.body = await cachedWpJsonFeed(ctx.query.url)
 }
 
 export async function carletonNow(ctx) {
+	ctx.cacheControl(ONE_HOUR)
+
 	let url = 'https://apps.carleton.edu/media_relations/feeds/blogs/news'
 	ctx.body = await cachedRssFeed(url)
 }
 export async function carletonian(ctx) {
+	ctx.cacheControl(ONE_HOUR)
+
 	let url = 'https://apps.carleton.edu/carletonian/feeds/blogs/tonian'
 	ctx.body = await cachedRssFeed(url)
 }
 export async function krlxNews(ctx) {
+	ctx.cacheControl(ONE_HOUR)
+
 	let url = 'http://www.krlx.org/wp-json/wp/v2/posts/'
 	// eslint-disable-next-line camelcase
 	ctx.body = await cachedWpJsonFeed(url, {per_page: 10, _embed: true})

--- a/modules/node_modules/@frogpond/ccci-carleton-college/v1/orgs/index.js
+++ b/modules/node_modules/@frogpond/ccci-carleton-college/v1/orgs/index.js
@@ -1,3 +1,4 @@
+
 import {get, ONE_HOUR} from '@frogpond/ccc-lib'
 import mem from 'mem'
 import _jsdom from 'jsdom'
@@ -102,5 +103,7 @@ async function _getOrgs() {
 export const getOrgs = mem(_getOrgs, {maxAge: ONE_HOUR * 6})
 
 export async function orgs(ctx) {
+	ctx.cacheControl(ONE_HOUR * 6)
+
 	ctx.body = await getOrgs()
 }

--- a/modules/node_modules/@frogpond/ccci-carleton-college/v1/transit/index.js
+++ b/modules/node_modules/@frogpond/ccci-carleton-college/v1/transit/index.js
@@ -9,6 +9,8 @@ export function getBus() {
 }
 
 export async function bus(ctx) {
+	ctx.cacheControl(ONE_HOUR)
+
 	ctx.body = await getBus()
 }
 
@@ -19,5 +21,7 @@ export function getModes() {
 }
 
 export async function modes(ctx) {
+	ctx.cacheControl(ONE_HOUR)
+
 	ctx.body = await getModes()
 }

--- a/modules/node_modules/@frogpond/ccci-carleton-college/v1/webcams/index.js
+++ b/modules/node_modules/@frogpond/ccci-carleton-college/v1/webcams/index.js
@@ -11,5 +11,7 @@ export function getWebcams() {
 }
 
 export async function webcams(ctx) {
+	ctx.cacheControl(ONE_HOUR)
+
 	ctx.body = await getWebcams()
 }

--- a/modules/node_modules/@frogpond/ccci-stolaf-college/v1/calendar/index.js
+++ b/modules/node_modules/@frogpond/ccci-stolaf-college/v1/calendar/index.js
@@ -7,14 +7,16 @@ export const getGoogleCalendar = mem(googleCalendar, {maxAge: ONE_MINUTE})
 export const getReasonCalendar = mem(reasonCalendar, {maxAge: ONE_MINUTE})
 
 export async function google(ctx) {
-	let {id: calendarId} = ctx.query
 	ctx.cacheControl(ONE_MINUTE)
+
+	let {id: calendarId} = ctx.query
 	ctx.body = await getGoogleCalendar(calendarId)
 }
 
 export async function reason(ctx) {
-	let {url: calendarUrl} = ctx.query
 	ctx.cacheControl(ONE_MINUTE)
+
+	let {url: calendarUrl} = ctx.query
 	ctx.body = await getReasonCalendar(calendarUrl)
 }
 
@@ -23,26 +25,36 @@ export async function ics(ctx) {
 }
 
 export async function stolaf(ctx) {
+	ctx.cacheControl(ONE_MINUTE)
+
 	let id = '5g91il39n0sv4c2bjdv1jrvcpq4ulm4r@import.calendar.google.com'
 	ctx.body = await getGoogleCalendar(id)
 }
 
 export async function oleville(ctx) {
+	ctx.cacheControl(ONE_MINUTE)
+
 	let id = 'stolaf.edu_fvulqo4larnslel75740vglvko@group.calendar.google.com'
 	ctx.body = await getGoogleCalendar(id)
 }
 
 export async function northfield(ctx) {
+	ctx.cacheControl(ONE_MINUTE)
+
 	let id = 'thisisnorthfield@gmail.com'
 	ctx.body = await getGoogleCalendar(id)
 }
 
 export async function krlx(ctx) {
+	ctx.cacheControl(ONE_MINUTE)
+
 	let id = 'krlxradio88.1@gmail.com'
 	ctx.body = await getGoogleCalendar(id)
 }
 
 export async function ksto(ctx) {
+	ctx.cacheControl(ONE_MINUTE)
+
 	let id = 'kstonarwhal@gmail.com'
 	ctx.body = await getGoogleCalendar(id)
 }

--- a/modules/node_modules/@frogpond/ccci-stolaf-college/v1/calendar/index.js
+++ b/modules/node_modules/@frogpond/ccci-stolaf-college/v1/calendar/index.js
@@ -8,11 +8,13 @@ export const getReasonCalendar = mem(reasonCalendar, {maxAge: ONE_MINUTE})
 
 export async function google(ctx) {
 	let {id: calendarId} = ctx.query
+	ctx.cacheControl(ONE_MINUTE)
 	ctx.body = await getGoogleCalendar(calendarId)
 }
 
 export async function reason(ctx) {
 	let {url: calendarUrl} = ctx.query
+	ctx.cacheControl(ONE_MINUTE)
 	ctx.body = await getReasonCalendar(calendarUrl)
 }
 

--- a/modules/node_modules/@frogpond/ccci-stolaf-college/v1/contacts/index.js
+++ b/modules/node_modules/@frogpond/ccci-stolaf-college/v1/contacts/index.js
@@ -11,5 +11,6 @@ export function getContacts() {
 }
 
 export async function contacts(ctx) {
+	ctx.cacheControl(ONE_DAY)
 	ctx.body = await getContacts()
 }

--- a/modules/node_modules/@frogpond/ccci-stolaf-college/v1/contacts/index.js
+++ b/modules/node_modules/@frogpond/ccci-stolaf-college/v1/contacts/index.js
@@ -12,5 +12,6 @@ export function getContacts() {
 
 export async function contacts(ctx) {
 	ctx.cacheControl(ONE_DAY)
+
 	ctx.body = await getContacts()
 }

--- a/modules/node_modules/@frogpond/ccci-stolaf-college/v1/departments/index.js
+++ b/modules/node_modules/@frogpond/ccci-stolaf-college/v1/departments/index.js
@@ -9,5 +9,6 @@ export function getDepartments() {
 }
 
 export async function departments(ctx) {
+	ctx.cacheControl(ONE_DAY)
 	ctx.body = await getDepartments()
 }

--- a/modules/node_modules/@frogpond/ccci-stolaf-college/v1/departments/index.js
+++ b/modules/node_modules/@frogpond/ccci-stolaf-college/v1/departments/index.js
@@ -10,5 +10,6 @@ export function getDepartments() {
 
 export async function departments(ctx) {
 	ctx.cacheControl(ONE_DAY)
+
 	ctx.body = await getDepartments()
 }

--- a/modules/node_modules/@frogpond/ccci-stolaf-college/v1/dictionary/index.js
+++ b/modules/node_modules/@frogpond/ccci-stolaf-college/v1/dictionary/index.js
@@ -11,5 +11,7 @@ export function getDictionary() {
 }
 
 export async function dictionary(ctx) {
+	ctx.cacheControl(ONE_DAY)
+
 	ctx.body = await getDictionary()
 }

--- a/modules/node_modules/@frogpond/ccci-stolaf-college/v1/faqs/index.js
+++ b/modules/node_modules/@frogpond/ccci-stolaf-college/v1/faqs/index.js
@@ -11,5 +11,7 @@ export function getFaqs() {
 }
 
 export async function faqs(ctx) {
+	ctx.cacheControl(ONE_DAY)
+
 	ctx.body = await getFaqs()
 }

--- a/modules/node_modules/@frogpond/ccci-stolaf-college/v1/help/index.js
+++ b/modules/node_modules/@frogpond/ccci-stolaf-college/v1/help/index.js
@@ -11,5 +11,7 @@ export function getHelp() {
 }
 
 export async function help(ctx) {
+	ctx.cacheControl(ONE_DAY)
+
 	ctx.body = await getHelp()
 }

--- a/modules/node_modules/@frogpond/ccci-stolaf-college/v1/hours/index.js
+++ b/modules/node_modules/@frogpond/ccci-stolaf-college/v1/hours/index.js
@@ -11,5 +11,7 @@ export function getBuildingHours() {
 }
 
 export async function buildingHours(ctx) {
+	ctx.cacheControl(ONE_HOUR)
+
 	ctx.body = await getBuildingHours()
 }

--- a/modules/node_modules/@frogpond/ccci-stolaf-college/v1/jobs/index.js
+++ b/modules/node_modules/@frogpond/ccci-stolaf-college/v1/jobs/index.js
@@ -98,5 +98,7 @@ async function _getJobs() {
 export const getJobs = mem(_getJobs, {maxAge: ONE_DAY})
 
 export async function jobs(ctx) {
+	ctx.cacheControl(ONE_DAY)
+
 	ctx.body = await getJobs()
 }

--- a/modules/node_modules/@frogpond/ccci-stolaf-college/v1/majors/index.js
+++ b/modules/node_modules/@frogpond/ccci-stolaf-college/v1/majors/index.js
@@ -9,5 +9,7 @@ export function getMajors() {
 }
 
 export async function majors(ctx) {
+	ctx.cacheControl(ONE_DAY)
+
 	ctx.body = await getMajors()
 }

--- a/modules/node_modules/@frogpond/ccci-stolaf-college/v1/menu/index.js
+++ b/modules/node_modules/@frogpond/ccci-stolaf-college/v1/menu/index.js
@@ -14,18 +14,26 @@ const getNutrition = mem(bonapp.nutrition, {maxAge: ONE_HOUR})
 export const getCafe = cafeId => Promise.all([getMenu(cafeId), getInfo(cafeId)])
 
 export async function pauseMenu(ctx) {
+	ctx.cacheControl(ONE_HOUR)
+
 	ctx.body = await getPauseMenu().then(resp => resp.body)
 }
 
 export async function bonAppMenu(ctx) {
+	ctx.cacheControl(ONE_HOUR)
+
 	ctx.body = await getMenu(ctx.params.cafeId)
 }
 
 export async function bonAppCafe(ctx) {
+	ctx.cacheControl(ONE_HOUR)
+
 	ctx.body = await getInfo(ctx.params.cafeId)
 }
 
 export async function bonAppNutrition(ctx) {
+	ctx.cacheControl(ONE_HOUR)
+
 	ctx.body = await getNutrition(ctx.params.itemId)
 }
 
@@ -40,57 +48,85 @@ let cafeIds = {
 }
 
 export async function stavCafe(ctx) {
+	ctx.cacheControl(ONE_HOUR)
+
 	ctx.body = await getInfo(cafeIds.stav)
 }
 
 export async function stavMenu(ctx) {
+	ctx.cacheControl(ONE_HOUR)
+
 	ctx.body = await getMenu(cafeIds.stav)
 }
 
 export async function cageCafe(ctx) {
+	ctx.cacheControl(ONE_HOUR)
+
 	ctx.body = await getInfo(cafeIds.cage)
 }
 
 export async function cageMenu(ctx) {
+	ctx.cacheControl(ONE_HOUR)
+
 	ctx.body = await getMenu(cafeIds.cage)
 }
 
 export async function kingsRoomCafe(ctx) {
+	ctx.cacheControl(ONE_HOUR)
+
 	ctx.body = await getInfo(cafeIds.kingsRoom)
 }
 
 export async function kingsRoomMenu(ctx) {
+	ctx.cacheControl(ONE_HOUR)
+
 	ctx.body = await getMenu(cafeIds.kingsRoom)
 }
 
 export async function burtonCafe(ctx) {
+	ctx.cacheControl(ONE_HOUR)
+
 	ctx.body = await getInfo(cafeIds.burton)
 }
 
 export async function burtonMenu(ctx) {
+	ctx.cacheControl(ONE_HOUR)
+
 	ctx.body = await getMenu(cafeIds.burton)
 }
 
 export async function ldcCafe(ctx) {
+	ctx.cacheControl(ONE_HOUR)
+
 	ctx.body = await getInfo(cafeIds.ldc)
 }
 
 export async function ldcMenu(ctx) {
+	ctx.cacheControl(ONE_HOUR)
+
 	ctx.body = await getMenu(cafeIds.ldc)
 }
 
 export async function saylesCafe(ctx) {
+	ctx.cacheControl(ONE_HOUR)
+
 	ctx.body = await getInfo(cafeIds.sayles)
 }
 
 export async function saylesMenu(ctx) {
+	ctx.cacheControl(ONE_HOUR)
+
 	ctx.body = await getMenu(cafeIds.sayles)
 }
 
 export async function weitzCafe(ctx) {
+	ctx.cacheControl(ONE_HOUR)
+
 	ctx.body = await getInfo(cafeIds.weitz)
 }
 
 export async function weitzMenu(ctx) {
+	ctx.cacheControl(ONE_HOUR)
+
 	ctx.body = await getMenu(cafeIds.weitz)
 }

--- a/modules/node_modules/@frogpond/ccci-stolaf-college/v1/news/index.js
+++ b/modules/node_modules/@frogpond/ccci-stolaf-college/v1/news/index.js
@@ -9,39 +9,55 @@ export const cachedRssFeed = mem(fetchRssFeed, {maxAge: ONE_HOUR})
 export const cachedWpJsonFeed = mem(fetchWpJson, {maxAge: ONE_HOUR})
 
 export async function rss(ctx) {
+	ctx.cacheControl(ONE_HOUR)
+
 	ctx.body = await cachedRssFeed(ctx.query.url)
 }
 
 export async function wpJson(ctx) {
+	ctx.cacheControl(ONE_HOUR)
+
 	ctx.body = await cachedWpJsonFeed(ctx.query.url)
 }
 
 export async function stolaf(ctx) {
+	ctx.cacheControl(ONE_HOUR)
+
 	let url = 'https://wp.stolaf.edu/wp-json/wp/v2/posts'
 	ctx.body = await cachedWpJsonFeed(url, {per_page: 10, _embed: true})
 }
 
 export async function oleville(ctx) {
+	ctx.cacheControl(ONE_HOUR)
+
 	let url = 'https://oleville.com/wp-json/wp/v2/posts/'
 	ctx.body = await cachedWpJsonFeed(url, {per_page: 10, _embed: true})
 }
 
 export async function politicole(ctx) {
+	ctx.cacheControl(ONE_HOUR)
+
 	let url = 'https://oleville.com/politicole/wp-json/wp/v2/posts/'
 	ctx.body = await cachedWpJsonFeed(url, {per_page: 10, _embed: true})
 }
 
 export async function mess(ctx) {
+	ctx.cacheControl(ONE_HOUR)
+
 	let url = 'https://www.manitoumessenger.com/wp-json/wp/v2/posts/'
 	ctx.body = await cachedWpJsonFeed(url, {per_page: 10, _embed: true})
 }
 
 export async function ksto(ctx) {
+	ctx.cacheControl(ONE_HOUR)
+
 	let url = 'https://kstoradio.org/wp-json/wp/v2/posts/'
 	ctx.body = await cachedWpJsonFeed(url, {per_page: 10, _embed: true})
 }
 
 export async function krlx(ctx) {
+	ctx.cacheControl(ONE_HOUR)
+
 	let url = 'https://www.krlx.org/wp-json/wp/v2/posts/'
 	ctx.body = await cachedWpJsonFeed(url, {per_page: 10, _embed: true})
 }

--- a/modules/node_modules/@frogpond/ccci-stolaf-college/v1/orgs/index.js
+++ b/modules/node_modules/@frogpond/ccci-stolaf-college/v1/orgs/index.js
@@ -61,8 +61,12 @@ async function _getOrgs() {
 	return sortBy(withSortableNames, '$sortableName')
 }
 
-export const getOrgs = mem(_getOrgs, {maxAge: ONE_HOUR * 6})
+const CACHE_DURATION = ONE_HOUR * 6
+
+export const getOrgs = mem(_getOrgs, {maxAge: CACHE_DURATION})
 
 export async function orgs(ctx) {
+	ctx.cacheControl(CACHE_DURATION)
+
 	ctx.body = await getOrgs()
 }

--- a/modules/node_modules/@frogpond/ccci-stolaf-college/v1/printing/index.js
+++ b/modules/node_modules/@frogpond/ccci-stolaf-college/v1/printing/index.js
@@ -11,5 +11,7 @@ export function getColorPrinters() {
 }
 
 export async function colorPrinters(ctx) {
+	ctx.cacheControl(ONE_DAY)
+
 	ctx.body = await getColorPrinters()
 }

--- a/modules/node_modules/@frogpond/ccci-stolaf-college/v1/streams/index.js
+++ b/modules/node_modules/@frogpond/ccci-stolaf-college/v1/streams/index.js
@@ -1,8 +1,8 @@
-import {get, ONE_DAY} from '@frogpond/ccc-lib'
+import {get, ONE_HOUR} from '@frogpond/ccc-lib'
 import mem from 'mem'
 import moment from 'moment-timezone'
 
-const GET = mem(get, {maxAge: ONE_DAY})
+const GET = mem(get, {maxAge: ONE_HOUR})
 
 export async function getStreams({streamClass, sort, dateFrom, dateTo}) {
 	const params = {
@@ -32,6 +32,8 @@ export async function getStreams({streamClass, sort, dateFrom, dateTo}) {
 }
 
 export async function upcoming(ctx) {
+	ctx.cacheControl(ONE_HOUR)
+
 	const {
 		dateFrom = moment()
 			.tz('America/Chicago')
@@ -52,6 +54,8 @@ export async function upcoming(ctx) {
 }
 
 export async function archived(ctx) {
+	ctx.cacheControl(ONE_HOUR)
+
 	const {
 		dateFrom = moment()
 			.subtract(2, 'month')

--- a/modules/node_modules/@frogpond/ccci-stolaf-college/v1/transit/index.js
+++ b/modules/node_modules/@frogpond/ccci-stolaf-college/v1/transit/index.js
@@ -9,6 +9,8 @@ export function getBus() {
 }
 
 export async function bus(ctx) {
+	ctx.cacheControl(ONE_HOUR)
+
 	ctx.body = await getBus()
 }
 
@@ -19,5 +21,7 @@ export function getModes() {
 }
 
 export async function modes(ctx) {
+	ctx.cacheControl(ONE_HOUR)
+
 	ctx.body = await getModes()
 }

--- a/modules/node_modules/@frogpond/ccci-stolaf-college/v1/webcams/index.js
+++ b/modules/node_modules/@frogpond/ccci-stolaf-college/v1/webcams/index.js
@@ -11,5 +11,7 @@ export function getWebcams() {
 }
 
 export async function webcams(ctx) {
+	ctx.cacheControl(ONE_DAY)
+
 	ctx.body = await getWebcams()
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -283,7 +283,7 @@
     },
     "apollo-tracing": {
       "version": "0.1.4",
-      "resolved": "http://registry.npmjs.org/apollo-tracing/-/apollo-tracing-0.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/apollo-tracing/-/apollo-tracing-0.1.4.tgz",
       "integrity": "sha512-Uv+1nh5AsNmC3m130i2u3IqbS+nrxyVV3KYimH5QKsdPjxxIQB3JAT+jJmpeDxBel8gDVstNmCh82QSLxLSIdQ==",
       "requires": {
         "graphql-extensions": "~0.0.9"
@@ -1284,7 +1284,7 @@
     },
     "graphql": {
       "version": "0.13.2",
-      "resolved": "http://registry.npmjs.org/graphql/-/graphql-0.13.2.tgz",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-0.13.2.tgz",
       "integrity": "sha512-QZ5BL8ZO/B20VA8APauGBg3GyEgZ19eduvpLWoq5x7gMmWnHoy8rlQWPLmWgFvo1yNgjSEFMesmS4R6pPr7xog==",
       "requires": {
         "iterall": "^1.2.1"
@@ -1292,7 +1292,7 @@
     },
     "graphql-extensions": {
       "version": "0.0.10",
-      "resolved": "http://registry.npmjs.org/graphql-extensions/-/graphql-extensions-0.0.10.tgz",
+      "resolved": "https://registry.npmjs.org/graphql-extensions/-/graphql-extensions-0.0.10.tgz",
       "integrity": "sha512-TnQueqUDCYzOSrpQb3q1ngDSP2otJSF+9yNLrQGPzkMsvnQ+v6e2d5tl+B35D4y+XpmvVnAn4T3ZK28mkILveA==",
       "requires": {
         "core-js": "^2.5.3",
@@ -2668,7 +2668,7 @@
     },
     "strip-eof": {
       "version": "1.0.0",
-      "resolved": "http://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
       "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
       "dev": true
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1808,6 +1808,14 @@
         }
       }
     },
+    "koa-ctx-cache-control": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/koa-ctx-cache-control/-/koa-ctx-cache-control-1.0.1.tgz",
+      "integrity": "sha512-r0OniNTTLs0PvqjOKgydVFqb8l8wuSDDTVwwVZyyXfpHOpe+21Lk/6njXm6LDVxGZY2/QCTInN21fSg7fmEMUA==",
+      "requires": {
+        "ms": "^2.0.0"
+      }
+    },
     "koa-etag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/koa-etag/-/koa-etag-3.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "koa-bodyparser": "4.2.1",
     "koa-compress": "3.0.0",
     "koa-conditional-get": "2.0.0",
+    "koa-ctx-cache-control": "^1.0.1",
     "koa-etag": "3.0.0",
     "koa-json-error": "3.1.2",
     "koa-logger": "3.2.0",


### PR DESCRIPTION
Closes #142

We just need to go through each file and add `ctx.cacheControl(N)`, where N is the same value that we pass to `get`.

```http
GET /v1/contacts
Server: localhost:3000
```

```http
HTTP/1.1 200 OK
Cache-Control: public, max-age=86400
Connection: keep-alive
Content-Encoding: gzip
Content-Type: application/json; charset=utf-8
Date: Tue, 18 Dec 2018 16:03:11 GMT
ETag: "216f-oazyKwCLvo0X6zy0IXm1Dvmq2XM"
Transfer-Encoding: chunked
Vary: Accept-Encoding
X-Response-Time: 2ms
```

This can either be an all-encompassing PR or the first of many PRs. All are welcome to add to this branch.