### PR TITLE
Categories on wp-json news articles

### DIFF
--- a/modules/node_modules/@frogpond/ccc-wpjson-feed/index.js
+++ b/modules/node_modules/@frogpond/ccc-wpjson-feed/index.js
@@ -10,8 +10,8 @@ export async function fetchWpJson(url, query = {}) {
 export function convertWpJsonItemToStory(item) {
 	let categories = []
 	if (item._embedded && item._embedded['wp:term']) {
-		categories = item._embedded['wp:term'].flatMap(cat =>
-			cat.filter(c => c.taxonomy === 'category').map(c => c.name),
+		categories = item._embedded['wp:term'].flatMap(category =>
+			category.filter(c => c.taxonomy === 'category').map(c => c.name),
 		)
 	}
 

--- a/modules/node_modules/@frogpond/ccc-wpjson-feed/index.js
+++ b/modules/node_modules/@frogpond/ccc-wpjson-feed/index.js
@@ -8,7 +8,7 @@ export async function fetchWpJson(url, query = {}) {
 }
 
 export function convertWpJsonItemToStory(item) {
-	let categories
+	let categories = []
 	if (item._embedded && item._embedded['wp:term']) {
 		categories = item._embedded['wp:term'].flatMap(cat =>
 			cat.filter(c => c.taxonomy === 'category').map(cat => cat.name),

--- a/modules/node_modules/@frogpond/ccc-wpjson-feed/index.js
+++ b/modules/node_modules/@frogpond/ccc-wpjson-feed/index.js
@@ -11,7 +11,7 @@ export function convertWpJsonItemToStory(item) {
 	let categories = []
 	if (item._embedded && item._embedded['wp:term']) {
 		categories = item._embedded['wp:term'].flatMap(cat =>
-			cat.filter(c => c.taxonomy === 'category').map(cat => cat.name),
+			cat.filter(c => c.taxonomy === 'category').map(c => c.name),
 		)
 	}
 

--- a/modules/node_modules/@frogpond/ccc-wpjson-feed/index.js
+++ b/modules/node_modules/@frogpond/ccc-wpjson-feed/index.js
@@ -8,6 +8,13 @@ export async function fetchWpJson(url, query = {}) {
 }
 
 export function convertWpJsonItemToStory(item) {
+	let categories
+	if (item._embedded && item._embedded['wp:term']) {
+		categories = item._embedded['wp:term'].flatMap(cat =>
+			cat.filter(c => c.taxonomy === 'category').map(cat => cat.name),
+		)
+	}
+
 	let author = item.author
 	if (item._embedded && item._embedded.author) {
 		let authorInfo = item._embedded.author.find(a => a.id === item.author)
@@ -37,7 +44,7 @@ export function convertWpJsonItemToStory(item) {
 
 	return {
 		authors: [author],
-		categories: [],
+		categories: categories,
 		content: item.content.rendered,
 		datePublished: item.date_gmt,
 		excerpt: JSDOM.fragment(item.excerpt.rendered).textContent.trim(),


### PR DESCRIPTION
Thanks to @hawkrives for helping clean this up out-of-band.

This lays the foundation for news filters by providing a filterable category in the wp-json feeds for future integration with filter-bar.

This PR filters down the embedded category metadata on a wp-json entry. It does not include "tags" (see the taxonomy level info) but will return an array of categories. I opted for multiple in the case that feeds other than krlx provide multiple categories. Otherwise, the majority of stories are tagged with one item.