### PR TITLE
Trim student work job contact name

### DIFF
--- a/modules/node_modules/@frogpond/ccci-stolaf-college/v1/jobs/index.js
+++ b/modules/node_modules/@frogpond/ccci-stolaf-college/v1/jobs/index.js
@@ -23,7 +23,7 @@ export function cleanJob(job) {
 
 	const contactFirstName = job.contactFirstName
 	const contactLastName = job.contactLastName
-	const contactName = `${contactFirstName} ${contactLastName}`
+	const contactName = `${contactFirstName} ${contactLastName}`.trim()
 
 	const links = getLinksFromJob({description, comments, skills, howToApply})
 


### PR DESCRIPTION
This serves to trim a contact's name in the event that both first and last name values are empty.

In the case of the [commencement and reunion ole ambassador](https://www.stolaf.edu/apps/stuwork/index.cfm?fuseaction=Details&jobID=876) job, we render a blank name for contact. This PR serves as a fix on the server for that.

Postings without a first or last name are considered valid input on the view as we're manually adding a space. The check in all about olaf's detail view is checking for a truthy value, and a string with a space passes that test.