### PR TITLE
Rename npm scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,8 +17,8 @@
     "pretty": "prettier --with-node-modules --write 'modules/**/*.js'",
     "lint": "eslint --cache 'modules/**/*.js'",
     "start": "node -r esm -r dotenv/config ./modules/node_modules/@frogpond/ccc-server/index.js",
-    "stolaf": "env INSTITUTION=stolaf-college npm start",
-    "carleton": "env INSTITUTION=carleton-college npm start",
+    "stolaf-college": "env INSTITUTION=stolaf-college npm start",
+    "carleton-college": "env INSTITUTION=carleton-college npm start",
     "test": "./scripts/smoke-test.sh"
   },
   "dependencies": {

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -10,11 +10,11 @@ if [[ ! $CI ]]; then
 fi
 
 # check that the server can launch properly, but don't bind to a port
-env SMOKE_TEST=1 npm run stolaf
+env SMOKE_TEST=1 npm run stolaf-college
 
 # launch and background the server, so we can test it
 PORT=3000
-env NODE_PORT=$PORT npm run stolaf &
+env NODE_PORT=$PORT npm run stolaf-college &
 
 # wait while the server starts up
 until nc -z -w5 localhost $PORT; do


### PR DESCRIPTION
I'm okay with keeping the jobs in `docker-compose.yml` named `stolaf` without the suffix as this produces container hostnames like `stolaf` or `cccserver_stolaf_1`; these are more concise and sufficiently clear.

We can consider this PR either Stage I of #147 or the entirety of it. Thoughts, @frog-pond/core?