### PR TITLE
switch st. olaf's orgs source to presence

### DIFF
--- a/modules/node_modules/@frogpond/ccc-presence/index.js
+++ b/modules/node_modules/@frogpond/ccc-presence/index.js
@@ -1,0 +1,89 @@
+import {get, ONE_HOUR} from '@frogpond/ccc-lib'
+import mem from 'mem'
+import lodash from 'lodash'
+import _jsdom from 'jsdom'
+import pMap from 'p-map'
+const {sortBy, startCase} = lodash
+const {JSDOM} = _jsdom
+
+/*
+type ContactPersonType = {
+	lastName: string,
+	title: string,
+	firstName: string,
+	email: string,
+}
+
+type AdvisorType = {
+	email: string,
+	name: string,
+}
+
+type StudentOrgType = {
+	meetings: string,
+	contacts: ContactPersonType[],
+	advisors: AdvisorType[],
+	description: string,
+	category: string,
+	lastUpdated: string,
+	website: string,
+	name: string,
+}
+*/
+
+export function cleanOrg(org) {
+	// console.log(org)
+
+	let name = org.name.trim()
+
+	// let contacts = org.contacts.map(c =>
+	// 	Object.assign({}, c, {
+	// 		title: c.title.trim(),
+	// 		firstName: c.firstName.trim(),
+	// 		lastName: c.lastName.trim(),
+	// 	}),
+	// )
+
+	let category = org.categories.join(', ')
+	let meetings = (org.regularMeetingLocation || '').trim() + (org.regularMeetingTime || '').trim()
+	let description = JSDOM.fragment(org.description).textContent.trim()
+	let website = (org.website || '').trim()
+	if (website && !/^https?:\/\//.test(website)) {
+		website = `http://${website}`
+	}
+
+	return {
+		advisors: [],
+		category,
+		contacts: [],
+		description,
+		lastUpdated: '2000-01-01',
+		meetings,
+		name,
+		website,
+	}
+}
+
+const fetchOrg = (base) => async (org) => (await get(`${base}/${org.uri}`, {json: true})).body
+
+export async function presence(school) {
+	let orgsUrl = `https://api.presence.io/${school}/v1/organizations`
+	let resp = await get(orgsUrl, {json: true})
+
+	let orgs = await pMap(resp.body, fetchOrg(orgsUrl), {concurrency: 8})
+
+	let cleaned = orgs.map(cleanOrg)
+
+	let sortableRegex = /^(St\.? Olaf(?: College)?|The) +/i
+	let withSortableNames = cleaned.map(item => {
+		let sortableName = item.name.replace(sortableRegex, '').toLowerCase()
+
+		return {
+			...item,
+			$sortableName: sortableName,
+			$groupableName: startCase(sortableName)[0].toUpperCase(),
+		}
+	})
+
+	return sortBy(withSortableNames, '$sortableName')
+}

--- a/modules/node_modules/@frogpond/ccc-presence/package.json
+++ b/modules/node_modules/@frogpond/ccc-presence/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@frogpond/ccc-presence",
+  "version": "1.0.0"
+}

--- a/modules/node_modules/@frogpond/ccci-stolaf-college/v1/orgs/index.js
+++ b/modules/node_modules/@frogpond/ccci-stolaf-college/v1/orgs/index.js
@@ -1,72 +1,14 @@
-import {get, ONE_HOUR} from '@frogpond/ccc-lib'
+import {ONE_HOUR} from '@frogpond/ccc-lib'
 import mem from 'mem'
-import lodash from 'lodash'
-import _jsdom from 'jsdom'
-const {sortBy, startCase} = lodash
-const {JSDOM} = _jsdom
 
-export function cleanOrg(org) {
-	let name = org.name.trim()
-
-	let advisors = org.advisors
-		.map(c => Object.assign({}, c, {name: c.name.trim()}))
-		.filter(c => c.name.length)
-
-	let contacts = org.contacts.map(c =>
-		Object.assign({}, c, {
-			title: c.title.trim(),
-			firstName: c.firstName.trim(),
-			lastName: c.lastName.trim(),
-		}),
-	)
-
-	let category = org.category.trim()
-	let meetings = org.meetings.trim()
-	let description = JSDOM.fragment(org.description).textContent.trim()
-	let website = org.website.trim()
-	if (website && !/^https?:\/\//.test(website)) {
-		website = `http://${website}`
-	}
-
-	return {
-		...org,
-		name,
-		advisors,
-		contacts,
-		category,
-		meetings,
-		description,
-		website,
-	}
-}
-
-async function _getOrgs() {
-	let orgsUrl = 'https://www.stolaf.edu/orgs/list/index.cfm'
-	let query = {fuseaction: 'getall', nostructure: '1'}
-	let resp = await get(orgsUrl, {json: true, query})
-
-	let cleaned = resp.body.map(cleanOrg)
-
-	let sortableRegex = /^(St\.? Olaf(?: College)?|The) +/i
-	let withSortableNames = cleaned.map(item => {
-		let sortableName = item.name.replace(sortableRegex, '')
-
-		return {
-			...item,
-			$sortableName: sortableName,
-			$groupableName: startCase(sortableName)[0],
-		}
-	})
-
-	return sortBy(withSortableNames, '$sortableName')
-}
+import {presence as _presence} from '@frogpond/ccc-presence'
 
 const CACHE_DURATION = ONE_HOUR * 6
 
-export const getOrgs = mem(_getOrgs, {maxAge: CACHE_DURATION})
+export const presence = mem(_presence, {maxAge: CACHE_DURATION})
 
 export async function orgs(ctx) {
 	ctx.cacheControl(CACHE_DURATION)
 
-	ctx.body = await getOrgs()
+	ctx.body = await presence('stolaf')
 }


### PR DESCRIPTION
This is an initial PR to switch to Presence for St. Olaf student orgs data.

@drewvolz I have currently blanked out the `advisors` and `contacts` arrays, since I don't know how to populate them… 

I've attached both the list response and the joined full data responses, if anyone wants to try and pull some more data out of them.

[Archive.zip](https://github.com/frog-pond/ccc-server/files/3674144/Archive.zip)
