### PR TITLE
Bump cache timeout to 36 hours for st. olaf orgs

### DIFF
--- a/modules/node_modules/@frogpond/ccci-stolaf-college/v1/orgs/index.js
+++ b/modules/node_modules/@frogpond/ccci-stolaf-college/v1/orgs/index.js
@@ -3,7 +3,7 @@ import mem from 'mem'
 
 import {presence as _presence} from '@frogpond/ccc-presence'
 
-const CACHE_DURATION = ONE_HOUR * 6
+const CACHE_DURATION = ONE_HOUR * 36
 
 export const presence = mem(_presence, {maxAge: CACHE_DURATION})
 


### PR DESCRIPTION
This is to reflect the changes in #291 which makes a more involved network request.