### PR TITLE
Fixup broken description parsing

### DIFF
--- a/modules/node_modules/@frogpond/ccci-carleton-college/v1/jobs/index.js
+++ b/modules/node_modules/@frogpond/ccci-carleton-college/v1/jobs/index.js
@@ -43,7 +43,9 @@ export async function fetchJob(link) {
 		if (BOOLEAN_KEYS.includes(key)) {
 			value = true
 		} else if (PARAGRAPHICAL_KEYS.includes(key)) {
-			value = [...listEl.querySelectorAll('p')]
+			let paragraphs = [...listEl.querySelectorAll('p')]
+			let content = paragraphs.length ? paragraphs : value
+			value = content
 				.map(el => el.textContent)
 				.join('\n\n')
 				.trim()


### PR DESCRIPTION
Looks like we won't always get paragraph elements in the job descriptions for Carleton. This PR checks if we found our elements, otherwise defaults to the plaintext. I'm opting to keep the paragraph element selection since we get nice formatting as a result.

📸 Screenshots

Before | After
--|--
![Simulator Screen Shot - iPhone 11 Pro Max - 2019-10-06 at 15 52 26](https://user-images.githubusercontent.com/5240843/66277629-10e84600-e856-11e9-8c74-043cd940b93b.png) |  ![Simulator Screen Shot - iPhone 11 Pro Max - 2019-10-06 at 15 50 01](https://user-images.githubusercontent.com/5240843/66277628-104faf80-e856-11e9-87d9-255aa88aee1e.png)
![Simulator Screen Shot - iPhone 11 Pro Max - 2019-10-06 at 15 52 28](https://user-images.githubusercontent.com/5240843/66277631-10e84600-e856-11e9-9ef0-41b423d87a1e.png) | ![Simulator Screen Shot - iPhone 11 Pro Max - 2019-10-06 at 15 49 59](https://user-images.githubusercontent.com/5240843/66277627-104faf80-e856-11e9-86d5-24b5581e9a39.png)
