### PR TITLE
Add a news source for carleton covid news

### DIFF
--- a/modules/node_modules/@frogpond/ccci-carleton-college/v1/index.js
+++ b/modules/node_modules/@frogpond/ccci-carleton-college/v1/index.js
@@ -98,6 +98,7 @@ api.get('/news/named/nnb', news.nnb)
 api.get('/news/named/carleton-now', news.carletonNow)
 api.get('/news/named/carletonian', news.carletonian)
 api.get('/news/named/krlx', news.krlxNews)
+api.get('/news/named/covid', news.covidNews)
 
 // hours
 api.get('/spaces/hours', hours.buildingHours)

--- a/modules/node_modules/@frogpond/ccci-carleton-college/v1/news/index.js
+++ b/modules/node_modules/@frogpond/ccci-carleton-college/v1/news/index.js
@@ -47,3 +47,11 @@ export async function krlxNews(ctx) {
 	// eslint-disable-next-line camelcase
 	ctx.body = await cachedWpJsonFeed(url, {per_page: 10, _embed: true})
 }
+
+export async function covidNews(ctx) {
+	ctx.cacheControl(ONE_HOUR)
+
+	let url = 'https://www.carleton.edu/covid/wp-json/wp/v2/posts'
+	// eslint-disable-next-line camelcase
+	ctx.body = await cachedWpJsonFeed(url)
+}


### PR DESCRIPTION
This adds a proxied network request to carleton's news endpoints for fetching COVID-19 campus news as per https://github.com/carls-app/carls/pull/328