### PR TITLE
circle: Specify a version when setting up remote Docker engine

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,7 +91,7 @@ jobs:
     <<: *defaults
     steps:
       - checkout
-      - setup_remote_docker
+      - setup_remote_docker: { version: 19.03.13 }
       - run:
           name: List docker images
           command: docker images -a
@@ -124,7 +124,7 @@ jobs:
     <<: *defaults
     steps:
       - checkout
-      - setup_remote_docker
+      - setup_remote_docker: { version: 19.03.13 }
       - restore_cache: *cache-load-docker
       - run: *cmd-docker-load
       - run: docker login -u "$DOCKER_USERNAME" -p "$DOCKER_PASSWORD"


### PR DESCRIPTION
As suggested in [this article][1], `setup_remote_docker` defaults to the `17.09.0-ce` version of Docker.  Since we don't depend too strongly on the internals of Docker being unchanged (and, more importantly, since [this article][1] seems to suggest the fix is to upgrade Docker) we can supply a version that should build just fine.

If this builds greenly, I think this might be what's needed to get our build working again.

[1]: https://support.circleci.com/hc/en-us/articles/360050934711-Docker-build-fails-with-EPERM-operation-not-permitted-copyfile-when-using-node-14-9-0-or-later-