### PR TITLE
Update carleton-now news endpoint to point to wordpress

### DIFF
--- a/modules/node_modules/@frogpond/ccci-carleton-college/v1/news/index.js
+++ b/modules/node_modules/@frogpond/ccci-carleton-college/v1/news/index.js
@@ -31,8 +31,9 @@ export async function wpJson(ctx) {
 export async function carletonNow(ctx) {
 	ctx.cacheControl(ONE_HOUR)
 
-	let url = 'https://apps.carleton.edu/media_relations/feeds/blogs/news'
-	ctx.body = await cachedRssFeed(url)
+	let url =
+		'https://www.carleton.edu/news/wp-json/wordpress-popular-posts/v1/popular-posts'
+	ctx.body = await cachedWpJsonFeed(url, {per_page: 10, _embed: true})
 }
 export async function carletonian(ctx) {
 	ctx.cacheControl(ONE_HOUR)


### PR DESCRIPTION
* Returns up-to-date news articles from their news homepage
* Tested by setting the simulator to use a local copy of ccci-carleton-college/news and articles loaded