### PR TITLE
Dependabot: Tweak some settings

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,4 +4,4 @@ updates:
   directory: "/"
   schedule:
     interval: daily
-  open-pull-requests-limit: 10
+  open-pull-requests-limit: 100

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,8 @@
 version: 2
 updates:
-- package-ecosystem: npm
-  directory: "/"
-  schedule:
-    interval: daily
-  open-pull-requests-limit: 100
-  commit-message: { prefix: "" }
+  - package-ecosystem: npm
+    directory: '/'
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 100
+    commit-message: {prefix: ''}

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,4 @@ updates:
   schedule:
     interval: daily
   open-pull-requests-limit: 100
+  commit-message: { prefix: "" }


### PR DESCRIPTION
- Bump the `open-pull-requests-limit` from `10` to `100`.
- Get rid of the "prefix" for commit messages (say "Bump <dep>" rather than prefixing with "build(...)")