### PR TITLE
Deprecate news sources

### DIFF
--- a/modules/node_modules/@frogpond/ccc-wpjson-feed/index.js
+++ b/modules/node_modules/@frogpond/ccc-wpjson-feed/index.js
@@ -57,7 +57,8 @@ export function convertWpJsonItemToStory(item) {
 export function deprecatedWpJson() {
 	return [{
 		content: "",
-		excerpt: "Please update your app.",
+		excerpt: "This news source is no longer being updated.",
+		url: "https://github.com/frog-pond/ccc-server/issues/563",
 		title: "Deprecated endpoint",
 	}]
 }

--- a/modules/node_modules/@frogpond/ccc-wpjson-feed/index.js
+++ b/modules/node_modules/@frogpond/ccc-wpjson-feed/index.js
@@ -58,7 +58,7 @@ export function deprecatedWpJson() {
 	return [{
 		content: "",
 		excerpt: "This news source is no longer being updated.",
-		url: "https://github.com/frog-pond/ccc-server/issues/563",
+		url: "https://github.com/frog-pond/ccc-server/discussions/564",
 		title: "Deprecated endpoint",
 	}]
 }

--- a/modules/node_modules/@frogpond/ccc-wpjson-feed/index.js
+++ b/modules/node_modules/@frogpond/ccc-wpjson-feed/index.js
@@ -53,3 +53,11 @@ export function convertWpJsonItemToStory(item) {
 		title: JSDOM.fragment(item.title.rendered).textContent.trim(),
 	}
 }
+
+export function deprecatedWpJson() {
+	return [{
+		content: "",
+		excerpt: "Please update your app.",
+		title: "Deprecated endpoint",
+	}]
+}

--- a/modules/node_modules/@frogpond/ccci-stolaf-college/v1/news/index.js
+++ b/modules/node_modules/@frogpond/ccci-stolaf-college/v1/news/index.js
@@ -2,7 +2,7 @@
 
 import {ONE_HOUR} from '@frogpond/ccc-lib'
 import {fetchRssFeed} from '@frogpond/ccc-rss-feed'
-import {fetchWpJson} from '@frogpond/ccc-wpjson-feed'
+import {fetchWpJson, deprecatedWpJson} from '@frogpond/ccc-wpjson-feed'
 import mem from 'mem'
 
 export const cachedRssFeed = mem(fetchRssFeed, {maxAge: ONE_HOUR})
@@ -35,10 +35,7 @@ export async function oleville(ctx) {
 }
 
 export async function politicole(ctx) {
-	ctx.cacheControl(ONE_HOUR)
-
-	let url = 'https://oleville.com/politicole/wp-json/wp/v2/posts/'
-	ctx.body = await cachedWpJsonFeed(url, {per_page: 10, _embed: true})
+	ctx.body = deprecatedWpJson()
 }
 
 export async function mess(ctx) {
@@ -49,10 +46,7 @@ export async function mess(ctx) {
 }
 
 export async function ksto(ctx) {
-	ctx.cacheControl(ONE_HOUR)
-
-	let url = 'https://kstoradio.org/wp-json/wp/v2/posts/'
-	ctx.body = await cachedWpJsonFeed(url, {per_page: 10, _embed: true})
+	ctx.body = deprecatedWpJson()
 }
 
 export async function krlx(ctx) {


### PR DESCRIPTION
- Paired with https://github.com/StoDevX/AAO-React-Native/pull/5363 to handle clients that still request these endpoints.
- Discussion for deprecated endpoints https://github.com/frog-pond/ccc-server/discussions/564  

<details>
<summary>📸 Screenshots</summary>

KSTO | PoliticOle
--|--
![1](https://user-images.githubusercontent.com/5240843/135197754-be982278-0acf-49a2-8dad-bf46d0138018.png) | ![2](https://user-images.githubusercontent.com/5240843/135197749-39cc7e2c-062a-4e56-8692-ea7c7f858ec2.png)


</details>