### PR TITLE
add a-to-z endpoint

### DIFF
--- a/modules/node_modules/@frogpond/ccci-stolaf-college/v1/a-to-z/index.js
+++ b/modules/node_modules/@frogpond/ccci-stolaf-college/v1/a-to-z/index.js
@@ -1,0 +1,46 @@
+import {get, ONE_DAY} from '@frogpond/ccc-lib'
+import mem from 'mem'
+import {GH_PAGES} from '../gh-pages'
+
+const GET = mem(get, {maxAge: ONE_DAY})
+
+function getOlafAtoZ() {
+	let url = 'https://wp.stolaf.edu/wp-json/site-data/sidebar/a-z'
+	return GET(url, {json: true}).then((resp) => resp.body)
+}
+
+function getPagesAtoZ() {
+	return GET(GH_PAGES('a-to-z.json'), {json: true}).then((resp) => resp.body)
+}
+
+// merge custom entries defined on GH pages with the fetched WP-JSON
+function combineResponses(pagesResponse, olafResponse) {
+	let olafData = olafResponse.az_nav.menu_items
+
+	pagesResponse.data.forEach(({letter, values}) => {
+		// find the matching keyed letter to add our own values to
+		let targetIndex = olafData.findIndex((entry) => entry.letter === letter)
+
+		if (targetIndex in olafData) {
+			// add our custom values and only resort the impacted indices
+			olafData[targetIndex].values.push(...values)
+			olafData[targetIndex].values.sort((a, b) =>
+				a.label.localeCompare(b.label),
+			)
+		}
+	})
+
+	return olafData.map(({letter, values}) => ({
+		title: letter[0],
+		data: values,
+	}))
+}
+
+export async function atoz(ctx) {
+	ctx.cacheControl(ONE_DAY)
+
+	let pagesResponse = await getPagesAtoZ()
+	let olafResponse = await getOlafAtoZ()
+
+	ctx.body = combineResponses(pagesResponse, olafResponse)
+}

--- a/modules/node_modules/@frogpond/ccci-stolaf-college/v1/index.js
+++ b/modules/node_modules/@frogpond/ccci-stolaf-college/v1/index.js
@@ -1,6 +1,7 @@
 import koaBody from 'koa-bodyparser'
 
 import Router from 'koa-router'
+import * as atoz from './a-to-z'
 import * as calendar from './calendar'
 import * as contacts from './contacts'
 import * as departments from './departments'
@@ -58,6 +59,9 @@ api.get('/calendar/named/oleville', calendar.oleville)
 api.get('/calendar/named/northfield', calendar.northfield)
 api.get('/calendar/named/krlx-schedule', calendar.krlx)
 api.get('/calendar/named/ksto-schedule', calendar.ksto)
+
+// a-to-z
+api.get('/a-to-z', atoz.atoz)
 
 // dictionary
 api.get('/dictionary', dictionary.dictionary)


### PR DESCRIPTION
- internally get data from `https://wp.stolaf.edu/wp-json/site-data/sidebar/a-z`
- internally get data from `GH_PAGES('a-to-z.json')` (currently exists on a [PR branch](https://github.com/StoDevX/AAO-React-Native/pull/6206))
- combine data, sort, map and return