### PR TITLE
Fix broken student jobs endpoint

### DIFF
--- a/modules/node_modules/@frogpond/ccc-html/index.js
+++ b/modules/node_modules/@frogpond/ccc-html/index.js
@@ -1,0 +1,64 @@
+/**
+ * Creates a map for consumption by `findHtmlKey` for fast key/value queries from html structures.
+ *
+ * Example:
+ * {
+ *  'Job Type' => '...',
+ *  'Job Description' => '...',
+ *  'key' => 'value',
+ * }
+ *
+ * @param {string} details  foo
+ * @param {Array<string>} paragraphicalKeys  A set of strings that are parsed as long-form content
+ * that receive separate parsing for line breaks and special characters.
+ * @returns {Map}
+ */
+export function getDetailMap(details, paragraphicalKeys) {
+	return [...details].reduce((coll, listEl) => {
+		let [key, ...value] = listEl.childNodes
+		key = key ? key.textContent.replace(/:$/, '') : key
+
+		if (paragraphicalKeys.includes(key)) {
+			let paragraphs = [...listEl.querySelectorAll('p')]
+			let content = paragraphs.length ? paragraphs : value
+			value = content
+				.map((el) => el.textContent)
+				.join('\n\n')
+				.trim()
+		} else {
+			value = value
+				.map((el) => el.textContent)
+				.join(' ')
+				.trim()
+		}
+		coll.set(key, value)
+
+		return coll
+	}, new Map())
+}
+
+/**
+ * Enables fast lookup of a named section of html content using the data structure
+ * generated from `getDetailMap`.
+ *
+ * For example, if we need to find  content associated with a section on a page
+ * named "Description", we call this function looking for that string along with
+ * the output from `getDetailMap` to quickly return the value for a key.
+ *
+ * @param {string} value  a key name to lookup
+ * @param {*} detailMap  a data structure containing the key:value content pairs
+ * @returns string
+ */
+export function findHtmlKey(value, detailMap) {
+	return detailMap.get(value) || ''
+}
+
+/**
+ * Replaces whitespace with an empty string.
+ *
+ * @param {string} text
+ * @returns string
+ */
+export function cleanTextBlock(text) {
+	return text.replace(/\s+/g, ' ')
+}

--- a/modules/node_modules/@frogpond/ccc-html/index.js
+++ b/modules/node_modules/@frogpond/ccc-html/index.js
@@ -8,7 +8,8 @@
  *  'key' => 'value',
  * }
  *
- * @param {string} details  foo
+ * @param {NodeListOf<HTML*Element>} details  Details is a node list of HTML{*}Element values.
+ * It is a scoped version of the webpage containing all of the html elements that we aim to parse.
  * @param {Array<string>} paragraphicalKeys  A set of strings that are parsed as long-form content
  * that receive separate parsing for line breaks and special characters.
  * @returns {Map}

--- a/modules/node_modules/@frogpond/ccc-html/index.js
+++ b/modules/node_modules/@frogpond/ccc-html/index.js
@@ -16,23 +16,23 @@
  */
 export function getDetailMap(details, paragraphicalKeys) {
 	return [...details].reduce((coll, listEl) => {
-		let [key, ...value] = listEl.childNodes
+		let [key, ...childNodeValue] = listEl.childNodes
 		key = key ? key.textContent.replace(/:$/, '') : key
 
 		if (paragraphicalKeys.includes(key)) {
 			let paragraphs = [...listEl.querySelectorAll('p')]
-			let content = paragraphs.length ? paragraphs : value
-			value = content
+			let content = paragraphs.length ? paragraphs : childNodeValue
+			childNodeValue = content
 				.map((el) => el.textContent)
 				.join('\n\n')
 				.trim()
 		} else {
-			value = value
+			childNodeValue = childNodeValue
 				.map((el) => el.textContent)
 				.join(' ')
 				.trim()
 		}
-		coll.set(key, value)
+		coll.set(key, childNodeValue)
 
 		return coll
 	}, new Map())

--- a/modules/node_modules/@frogpond/ccc-html/package.json
+++ b/modules/node_modules/@frogpond/ccc-html/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@frogpond/ccc-html",
+  "version": "1.0.0"
+}

--- a/modules/node_modules/@frogpond/ccci-stolaf-college/v1/jobs/index.js
+++ b/modules/node_modules/@frogpond/ccci-stolaf-college/v1/jobs/index.js
@@ -1,52 +1,85 @@
 import {get, ONE_DAY} from '@frogpond/ccc-lib'
 import mem from 'mem'
+import pMap from 'p-map'
 import _jsdom from 'jsdom'
 import getUrls from 'get-urls'
 
 const {JSDOM} = _jsdom
 
-export function cleanJob(job) {
-	// these all need to retain their newlines
-	const description = cleanTextBlock(
-		JSDOM.fragment(job.description).textContent,
-	)
-	const comments = cleanTextBlock(JSDOM.fragment(job.comments).textContent)
-	const skills = cleanTextBlock(JSDOM.fragment(job.skills).textContent)
-	const howToApply = cleanTextBlock(JSDOM.fragment(job.howToApply).textContent)
-	const timeline = cleanTextBlock(JSDOM.fragment(job.timeline).textContent)
-	const timeOfHours = cleanTextBlock(
-		JSDOM.fragment(job.timeOfHours).textContent,
-	)
+const jobsUrl =
+	'https://wp.stolaf.edu/student-jobs/wp-json/wp/v2/pages/80'
 
-	const contactEmail = fixupEmailFormat(job.contactEmail)
-	const contactPhone = fixupPhoneFormat(job.contactPhone)
+const PARAGRAPHICAL_KEYS = ['Job Description', 'Skills Needed', 'Additional Comments', 'How to Apply', 'Hiring Timeline']
 
-	const contactFirstName = job.contactFirstName
-	const contactLastName = job.contactLastName
+async function fetchDetail(url) {
+	const resp = await get(url)
+
+	// run-scripts value is needed to properly evaluate javascript to display an email address.
+	// see the jsdom documentation for more details https://github.com/jsdom/jsdom#executing-scripts
+	const dom = new JSDOM(resp.body, {contentType: 'text/html', runScripts: 'dangerously' })
+
+	const id = url.replace(/\D/g,'')
+	const titleText = dom.window.document.querySelector('.gv-list-view-title > h3').textContent
+	const details = dom.window.document.querySelectorAll('div')
+
+	const detailMap = [...details].reduce((coll, listEl) => {
+		let [key, ...value] = listEl.childNodes
+		key = key ? key.textContent.replace(/:$/, '') : key
+
+		if (PARAGRAPHICAL_KEYS.includes(key)) {
+			let paragraphs = [...listEl.querySelectorAll('p')]
+			let content = paragraphs.length ? paragraphs : value
+			value = content
+				.map((el) => el.textContent)
+				.join('\n\n')
+				.trim()
+		} else {
+			value = value
+				.map((el) => el.textContent)
+				.join(' ')
+				.trim()
+		}
+		coll.set(key, value)
+
+		return coll
+	}, new Map())
+
+	function findKey(value) {
+		return detailMap.get(value) || ''
+	}
+
+	const [contactFirstName, contactLastName] = findKey('Contact Person').split(' ')
 	const contactName = `${contactFirstName} ${contactLastName}`.trim()
+
+	const description = cleanTextBlock(findKey('Job Description'))
+	const comments = cleanTextBlock(findKey('Additional Comments'))
+	const skills = cleanTextBlock(findKey('Skills Needed'))
+	const howToApply = cleanTextBlock(findKey('How to Apply'))
+	const timeline = cleanTextBlock(findKey('Hiring Timeline'))
 
 	const links = getLinksFromJob({description, comments, skills, howToApply})
 
 	return {
 		comments: comments,
-		contactEmail: contactEmail,
+		contactEmail: fixupEmailFormat(findKey('Contact Email')),
 		contactName: contactName,
-		contactPhone: contactPhone,
+		contactPhone: fixupPhoneFormat(findKey('Phone Extension')),
 		description: description,
-		goodForIncomingStudents: job.goodForIncomingStudents,
-		hoursPerWeek: job.hoursPerWeek,
+		goodForIncomingStudents: Boolean(findKey('Appropriate for incoming/first-year students')),
+		hoursPerWeek: findKey('Hours/week'),
 		howToApply: howToApply,
-		id: job.id,
-		lastModified: job.lastModified,
+		id: id,
+		lastModified: findKey('Date Posted'),
 		links: links,
-		office: job.office,
-		openPositions: job.openPositions,
+		office: findKey('Office'),
+		openPositions: findKey('Number of Available Positions'),
 		skills: skills,
 		timeline: timeline,
-		timeOfHours: timeOfHours,
-		title: job.title,
-		type: job.type,
-		year: job.year,
+		timeOfHours: findKey('Time of Hours'),
+		title: titleText,
+		type: findKey('Job Type'),
+		url: url,
+		year: findKey('Job Year'),
 	}
 }
 
@@ -84,15 +117,58 @@ function fixupEmailFormat(email) {
 	}
 }
 
+function nextPageExists(dom) {
+	if (dom === undefined) {
+		return false
+	}
+
+	const elements = dom.window.document.querySelectorAll('.next.page-numbers')
+	return elements.length > 0
+}
+
+export function findPageUrls(dom) {
+	const linkElements =[
+		...dom.window.document.querySelectorAll('.gv-list-view > .gv-list-view-title > h3 > a')
+	]
+
+	return linkElements.map((url) => url.getAttribute('href'))
+}
+
+/**
+ * The wp-json response now provides a much rougher response that requires a lot
+ * of separate network requests that involve both json and html parsing in order
+ * for us to deliver the full props for each job posting.
+ * 
+ * In short:
+ * 1. [json] wp-json paginated requests to get page urls (1-3 requests for 25->50->75 entries)
+ * 2. [html] detail page html requests, involves html parsing and returning json (easily 50+ requests)
+ * 
+ * We end up making multiple requests to the wp-json endpoint to build up all of
+ * the top-level paginated urls, and then a request-per-post to get the details.
+ */
 async function _getJobs() {
-	let url = 'https://www.stolaf.edu/apps/stuwork/index.cfm'
-	let query = {fuseaction: 'getall', nostructure: '1'}
+	let allUrls = []
 
-	let data = await get(url, {json: true, query}).then((resp) => resp.body)
+	// the paginator (as of writing) starts off at 25 entries
+	// we are currently seeing 50 entries so we would expect to query this endpoint twice
+	let pageNumber = 1
 
-	let cleaned = data.map(cleanJob)
+	let previousDom = undefined
 
-	return cleaned
+	do {
+		const response = await get(`${jobsUrl}?pagenum=${pageNumber}`, {json: true})
+		const {rendered} = response.body.content
+		
+		const dom = new JSDOM(rendered, {contentType: 'text/html'})
+		previousDom = dom
+		pageNumber += 1
+
+		const fetchedUrls = findPageUrls(dom)
+		allUrls.push(...fetchedUrls)
+	}
+	while(nextPageExists(previousDom))
+
+	return pMap(allUrls, fetchDetail, {concurrency: 4})
 }
 
 export const getJobs = mem(_getJobs, {maxAge: ONE_DAY})

--- a/modules/node_modules/@frogpond/ccci-stolaf-college/v1/jobs/index.js
+++ b/modules/node_modules/@frogpond/ccci-stolaf-college/v1/jobs/index.js
@@ -25,37 +25,19 @@ const PARAGRAPHICAL_KEYS = [
 	'Hiring Timeline',
 ]
 
-async function fetchDetail(url) {
-	const resp = await GET_TWO_DAYS(url)
-
-	// run-scripts value is needed to properly evaluate javascript to display an email address.
-	// see the jsdom documentation for more details https://github.com/jsdom/jsdom#executing-scripts
-	const dom = new JSDOM(resp.body, {
-		contentType: 'text/html',
-		runScripts: 'dangerously',
-	})
-
+/**
+ * Builds a json response suitable for the client to render
+ *
+ * @param {*} url  the canonical url for the job detail page
+ * @param {*} dom  the JSDOM used for extracting one-off selectors
+ * @param {*} findKey  a function for extracting mapped job data
+ * @returns a cleaned, parsed, and formatted version of the data as JSON
+ */
+function buildJobDetailResponse(url, dom, findKey) {
 	const id = url.replace(/\D/g, '')
 	const titleText = dom.window.document.querySelector(
 		'.gv-list-view-title > h3',
 	).textContent
-
-	/**
-	 * Details is a node list of HTMLDivElement. It is a scoped version of the webpage containing
-	 * all of the text elements we need to parse (both keys and values) via `getDetailMap`.
-	 */
-	const details = dom.window.document.querySelectorAll('div')
-
-	/**
-	 * A key-value Map for querying text elements from html data.
-	 */
-	const detailMap = getDetailMap(details, PARAGRAPHICAL_KEYS)
-
-	/**
-	 * Wrapper function to simplify the api for calling `findHtmlKey` by centralizing where
-	 * the datastructure `detailMap` is passed-in to one place.
-	 */
-	const findKey = (key) => findHtmlKey(key, detailMap)
 
 	const [contactFirstName, contactLastName] =
 		findKey('Contact Person').split(' ')
@@ -93,6 +75,36 @@ async function fetchDetail(url) {
 		url: url,
 		year: findKey('Job Year'),
 	}
+}
+
+async function fetchDetail(url) {
+	const resp = await GET_TWO_DAYS(url)
+
+	// run-scripts value is needed to properly evaluate javascript to display an email address.
+	// see the jsdom documentation for more details https://github.com/jsdom/jsdom#executing-scripts
+	const dom = new JSDOM(resp.body, {
+		contentType: 'text/html',
+		runScripts: 'dangerously',
+	})
+
+	/**
+	 * Details is a node list of HTMLDivElement. It is a scoped version of the webpage containing
+	 * all of the text elements we need to parse (both keys and values) via `getDetailMap`.
+	 */
+	const details = dom.window.document.querySelectorAll('div')
+
+	/**
+	 * A key-value Map for querying text elements from html data.
+	 */
+	const detailMap = getDetailMap(details, PARAGRAPHICAL_KEYS)
+
+	/**
+	 * Wrapper function to simplify the api for calling `findHtmlKey` by centralizing where
+	 * the datastructure `detailMap` is passed-in to one place.
+	 */
+	const findKey = (key) => findHtmlKey(key, detailMap)
+
+	return buildJobDetailResponse(url, dom, findKey)
 }
 
 export function getLinksFromJob({description, comments, skills, howToApply}) {

--- a/modules/node_modules/@frogpond/ccci-stolaf-college/v1/jobs/index.js
+++ b/modules/node_modules/@frogpond/ccci-stolaf-college/v1/jobs/index.js
@@ -11,6 +11,11 @@ const GET_TWO_DAYS = mem(get, {maxAge: ONE_DAY * 2})
 
 const jobsUrl = 'https://wp.stolaf.edu/student-jobs/wp-json/wp/v2/pages/80'
 
+/**
+ * Set of keys in the html to target when looking at long-form content
+ * that we need to parse line breaks and special characters within. This
+ * is specific to the stolaf-college jobs detail page.
+ */
 const PARAGRAPHICAL_KEYS = [
 	'Job Description',
 	'Skills Needed',
@@ -33,6 +38,11 @@ async function fetchDetail(url) {
 	const titleText = dom.window.document.querySelector(
 		'.gv-list-view-title > h3',
 	).textContent
+
+	/**
+	 * Details is a node list of HTMLDivElement. It is a scoped version of the webpage containing
+	 * all of the text elements we need to parse (both keys and values) via `getDetailMap`.
+	 */
 	const details = dom.window.document.querySelectorAll('div')
 
 	const detailMap = [...details].reduce((coll, listEl) => {
@@ -60,6 +70,16 @@ async function fetchDetail(url) {
 	function findKey(value) {
 		return detailMap.get(value) || ''
 	}
+	/**
+	 * A key-value Map for querying text elements from html data.
+	 */
+	const detailMap = getDetailMap(details, PARAGRAPHICAL_KEYS)
+
+	/**
+	 * Wrapper function to simplify the api for calling `findHtmlKey` by centralizing where
+	 * the datastructure `detailMap` is passed-in to one place.
+	 */
+	const findKey = (key) => findHtmlKey(key, detailMap)
 
 	const [contactFirstName, contactLastName] =
 		findKey('Contact Person').split(' ')
@@ -133,6 +153,15 @@ function fixupEmailFormat(email) {
 	}
 }
 
+/**
+ * The paginator is included within the nested html. We can see if we need to continue requesting
+ * more data by checking if the button dedicated to clicking next is present.
+ *
+ * While there are are a few ways to go about parsing whether we've reached the last page, the
+ * paginator looks like it doesn't even know when it has reached the end of the results! Instead
+ * of trying to keep tracking of the amount of items we can opt to check the dom for the presence
+ * of the button.
+ */
 function nextPageExists(dom) {
 	if (dom === undefined) {
 		return false
@@ -142,6 +171,10 @@ function nextPageExists(dom) {
 	return elements.length > 0
 }
 
+/**
+ * The top-level results html provides a bunch of html with links to each posting. We can gather
+ * each link's href from these pages.
+ */
 export function findPageUrls(dom) {
 	const jobLinks = Array.from(
 		dom.window.document.querySelectorAll(

--- a/modules/node_modules/@frogpond/ccci-stolaf-college/v1/jobs/index.js
+++ b/modules/node_modules/@frogpond/ccci-stolaf-college/v1/jobs/index.js
@@ -6,6 +6,9 @@ import getUrls from 'get-urls'
 
 const {JSDOM} = _jsdom
 
+const GET_ONE_DAY = mem(get, {maxAge: ONE_DAY})
+const GET_TWO_DAYS = mem(get, {maxAge: ONE_DAY * 2})
+
 const jobsUrl = 'https://wp.stolaf.edu/student-jobs/wp-json/wp/v2/pages/80'
 
 const PARAGRAPHICAL_KEYS = [
@@ -17,7 +20,7 @@ const PARAGRAPHICAL_KEYS = [
 ]
 
 async function fetchDetail(url) {
-	const resp = await get(url)
+	const resp = await GET_TWO_DAYS(url)
 
 	// run-scripts value is needed to properly evaluate javascript to display an email address.
 	// see the jsdom documentation for more details https://github.com/jsdom/jsdom#executing-scripts
@@ -176,7 +179,9 @@ async function _getJobs() {
 	let previousDom = undefined
 
 	do {
-		const response = await get(`${jobsUrl}?pagenum=${pageNumber}`, {json: true})
+		const response = await GET_ONE_DAY(`${jobsUrl}?pagenum=${pageNumber}`, {
+			json: true,
+		})
 		const {rendered} = response.body.content
 
 		const dom = new JSDOM(rendered, {contentType: 'text/html'})

--- a/modules/node_modules/@frogpond/ccci-stolaf-college/v1/jobs/index.js
+++ b/modules/node_modules/@frogpond/ccci-stolaf-college/v1/jobs/index.js
@@ -1,4 +1,5 @@
 import {get, ONE_DAY} from '@frogpond/ccc-lib'
+import {cleanTextBlock, getDetailMap, findHtmlKey} from '@frogpond/ccc-html'
 import mem from 'mem'
 import pMap from 'p-map'
 import _jsdom from 'jsdom'
@@ -45,31 +46,6 @@ async function fetchDetail(url) {
 	 */
 	const details = dom.window.document.querySelectorAll('div')
 
-	const detailMap = [...details].reduce((coll, listEl) => {
-		let [key, ...value] = listEl.childNodes
-		key = key ? key.textContent.replace(/:$/, '') : key
-
-		if (PARAGRAPHICAL_KEYS.includes(key)) {
-			let paragraphs = [...listEl.querySelectorAll('p')]
-			let content = paragraphs.length ? paragraphs : value
-			value = content
-				.map((el) => el.textContent)
-				.join('\n\n')
-				.trim()
-		} else {
-			value = value
-				.map((el) => el.textContent)
-				.join(' ')
-				.trim()
-		}
-		coll.set(key, value)
-
-		return coll
-	}, new Map())
-
-	function findKey(value) {
-		return detailMap.get(value) || ''
-	}
 	/**
 	 * A key-value Map for querying text elements from html data.
 	 */
@@ -117,10 +93,6 @@ async function fetchDetail(url) {
 		url: url,
 		year: findKey('Job Year'),
 	}
-}
-
-function cleanTextBlock(text) {
-	return text.replace(/\s+/g, ' ')
 }
 
 export function getLinksFromJob({description, comments, skills, howToApply}) {

--- a/modules/node_modules/@frogpond/ccci-stolaf-college/v1/jobs/index.js
+++ b/modules/node_modules/@frogpond/ccci-stolaf-college/v1/jobs/index.js
@@ -135,22 +135,27 @@ export function findPageUrls(dom) {
 }
 
 /**
- * The wp-json response now provides a much rougher response that requires a lot
- * of separate network requests that involve both json and html parsing in order
- * for us to deliver the full props for each job posting.
- * 
- * In short:
+ * The coldfusion endpoint stopped providing a robust json api response and started serving
+ * a much rougher wp-json endpoint according to our logs on 09/27/2022. Implementation as of
+ * 10/16/2022 is designed around making a series of network requests that involve both json
+ * and html parsing to deliver the same set of props to match the client's api contract.
+ *
+ * In short, we are performing the following fetching and parsing steps:
  * 1. [json] wp-json paginated requests to get page urls (1-3 requests for 25->50->75 entries)
+ *           where we target html stored within a json field response
  * 2. [html] detail page html requests, involves html parsing and returning json (easily 50+ requests)
- * 
- * We end up making multiple requests to the wp-json endpoint to build up all of
- * the top-level paginated urls, and then a request-per-post to get the details.
+ *
+ * So we end up making multiple requests to the paginated wp-json endpoint to build a list of
+ * all job posting urls, and finally request each url we find to build our data.
  */
 async function _getJobs() {
 	let allUrls = []
 
-	// the paginator (as of writing) starts off at 25 entries
-	// we are currently seeing 50 entries so we would expect to query this endpoint twice
+	/**
+	 * The top-level wp-json endpoint which provides the list of job postings responds to a query
+	 * parameter named `pagenum`. The paginator as of 10/16/2022 lists 25 entries at a time, so if
+	 * we see 51 entries, we would expect to query this endpoint three times.
+	 */
 	let pageNumber = 1
 
 	let previousDom = undefined

--- a/modules/node_modules/@frogpond/ccci-stolaf-college/v1/jobs/index.js
+++ b/modules/node_modules/@frogpond/ccci-stolaf-college/v1/jobs/index.js
@@ -6,20 +6,30 @@ import getUrls from 'get-urls'
 
 const {JSDOM} = _jsdom
 
-const jobsUrl =
-	'https://wp.stolaf.edu/student-jobs/wp-json/wp/v2/pages/80'
+const jobsUrl = 'https://wp.stolaf.edu/student-jobs/wp-json/wp/v2/pages/80'
 
-const PARAGRAPHICAL_KEYS = ['Job Description', 'Skills Needed', 'Additional Comments', 'How to Apply', 'Hiring Timeline']
+const PARAGRAPHICAL_KEYS = [
+	'Job Description',
+	'Skills Needed',
+	'Additional Comments',
+	'How to Apply',
+	'Hiring Timeline',
+]
 
 async function fetchDetail(url) {
 	const resp = await get(url)
 
 	// run-scripts value is needed to properly evaluate javascript to display an email address.
 	// see the jsdom documentation for more details https://github.com/jsdom/jsdom#executing-scripts
-	const dom = new JSDOM(resp.body, {contentType: 'text/html', runScripts: 'dangerously' })
+	const dom = new JSDOM(resp.body, {
+		contentType: 'text/html',
+		runScripts: 'dangerously',
+	})
 
-	const id = url.replace(/\D/g,'')
-	const titleText = dom.window.document.querySelector('.gv-list-view-title > h3').textContent
+	const id = url.replace(/\D/g, '')
+	const titleText = dom.window.document.querySelector(
+		'.gv-list-view-title > h3',
+	).textContent
 	const details = dom.window.document.querySelectorAll('div')
 
 	const detailMap = [...details].reduce((coll, listEl) => {
@@ -48,7 +58,8 @@ async function fetchDetail(url) {
 		return detailMap.get(value) || ''
 	}
 
-	const [contactFirstName, contactLastName] = findKey('Contact Person').split(' ')
+	const [contactFirstName, contactLastName] =
+		findKey('Contact Person').split(' ')
 	const contactName = `${contactFirstName} ${contactLastName}`.trim()
 
 	const description = cleanTextBlock(findKey('Job Description'))
@@ -65,7 +76,9 @@ async function fetchDetail(url) {
 		contactName: contactName,
 		contactPhone: fixupPhoneFormat(findKey('Phone Extension')),
 		description: description,
-		goodForIncomingStudents: Boolean(findKey('Appropriate for incoming/first-year students')),
+		goodForIncomingStudents: Boolean(
+			findKey('Appropriate for incoming/first-year students'),
+		),
 		hoursPerWeek: findKey('Hours/week'),
 		howToApply: howToApply,
 		id: id,
@@ -127,8 +140,10 @@ function nextPageExists(dom) {
 }
 
 export function findPageUrls(dom) {
-	const linkElements =[
-		...dom.window.document.querySelectorAll('.gv-list-view > .gv-list-view-title > h3 > a')
+	const linkElements = [
+		...dom.window.document.querySelectorAll(
+			'.gv-list-view > .gv-list-view-title > h3 > a',
+		),
 	]
 
 	return linkElements.map((url) => url.getAttribute('href'))
@@ -163,15 +178,14 @@ async function _getJobs() {
 	do {
 		const response = await get(`${jobsUrl}?pagenum=${pageNumber}`, {json: true})
 		const {rendered} = response.body.content
-		
+
 		const dom = new JSDOM(rendered, {contentType: 'text/html'})
 		previousDom = dom
 		pageNumber += 1
 
 		const fetchedUrls = findPageUrls(dom)
 		allUrls.push(...fetchedUrls)
-	}
-	while(nextPageExists(previousDom))
+	} while (nextPageExists(previousDom))
 
 	return pMap(allUrls, fetchDetail, {concurrency: 4})
 }

--- a/modules/node_modules/@frogpond/ccci-stolaf-college/v1/jobs/index.js
+++ b/modules/node_modules/@frogpond/ccci-stolaf-college/v1/jobs/index.js
@@ -140,13 +140,13 @@ function nextPageExists(dom) {
 }
 
 export function findPageUrls(dom) {
-	const linkElements = [
-		...dom.window.document.querySelectorAll(
+	const jobLinks = Array.from(
+		dom.window.document.querySelectorAll(
 			'.gv-list-view > .gv-list-view-title > h3 > a',
 		),
-	]
+	).map((url) => url.getAttribute('href'))
 
-	return linkElements.map((url) => url.getAttribute('href'))
+	return jobLinks
 }
 
 /**


### PR DESCRIPTION
## Context 
The coldfusion endpoint stopped providing a robust json api response and started serving a much rougher wp-json endpoint according to our logs on 09/27/2022. 

## Approach

Implementation as of 10/16/2022 is designed around making a series of network requests that involve both json and html parsing to deliver the same set of props to match the client's api contract.

In short, we are performing the following fetching and parsing steps:
1. [json] wp-json paginated requests to get page urls where we target html stored within a json field response (1-3 requests for 25->50->75 entries) 
2. [html] detail page html requests, involves html parsing and returning json (easily 50+ requests)

So we end up making multiple requests to the paginated wp-json endpoint to build a list of all job posting urls, and finally request each url we find to build our data.