### PR TITLE
update user agent

### DIFF
--- a/modules/node_modules/@frogpond/ccc-lib/http.js
+++ b/modules/node_modules/@frogpond/ccc-lib/http.js
@@ -1,6 +1,7 @@
 import got from 'got'
+import process from 'process'
 
-export const USER_AGENT = 'ccc-server/1.0.0 (docker, node 10)'
+export const USER_AGENT = `ccc-server/0.1.0 (docker 20.10.17; node ${process.versions.node})`
 
 export const get = (url, opts) =>
 	got(url, Object.assign({headers: {'User-Agent': USER_AGENT}}, opts))

--- a/modules/node_modules/@frogpond/ccc-lib/http.js
+++ b/modules/node_modules/@frogpond/ccc-lib/http.js
@@ -1,5 +1,4 @@
 import got from 'got'
-import process from 'process'
 
 export const USER_AGENT = `ccc-server/0.1.0 (docker 20.10.17; node ${process.versions.node})`
 


### PR DESCRIPTION
- closes #35 
- part of #34
- part of #36

--- 

[Comment from Kris](https://github.com/frog-pond/ccc-server/issues/34#issuecomment-386063578) on `ccc-server/x.y.z` versioning

> We haven't published an API. This project is not at v1 yet, and we should therefore change our version to match that. (I'd be fine with v0.1, and just incrementing the minor version for each release.) This change needs to be made whenever we start a release workflow.

Docker version looks to remain the same

```sh
> docker -v
Docker version 20.10.17, build 100c701
```

Node version can be passed-in from `process.versions`. Checking against the following

```sh
> docker run -it --rm docker.io/frogpond/ccc-server:HEAD node -v
v12.22.12
```