### PR TITLE
user agent with docker info

### DIFF
--- a/modules/node_modules/@frogpond/ccc-lib/http.js
+++ b/modules/node_modules/@frogpond/ccc-lib/http.js
@@ -1,6 +1,6 @@
 import got from 'got'
 
-export const USER_AGENT = `ccc-server/0.1.0 (docker 20.10.17; node ${process.versions.node})`
+export const USER_AGENT = `ccc-server/0.1.0 (docker ${process.env.DOCKER_VERSION}; node ${process.versions.node})`
 
 export const get = (url, opts) =>
 	got(url, Object.assign({headers: {'User-Agent': USER_AGENT}}, opts))

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "start": "node -r esm -r dotenv/config ./modules/node_modules/@frogpond/ccc-server/index.js",
     "stolaf-college": "env INSTITUTION=stolaf-college yarn start",
     "carleton-college": "env INSTITUTION=carleton-college yarn start",
-    "test": "./scripts/smoke-test.sh"
+    "test": "./scripts/smoke-test.sh",
+    "docker-version": "./scripts/docker-version.sh"
   },
   "dependencies": {
     "dotenv": "10.0.0",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "p": "pretty-quick",
     "pretty": "prettier --with-node-modules --write 'modules/**/*.js'",
     "lint": "eslint --ignore-pattern '!modules/node_modules/*' --cache",
-    "start": "node -r esm -r dotenv/config ./modules/node_modules/@frogpond/ccc-server/index.js",
+    "start": "DOCKER_VERSION=$(yarn --silent docker-version) node -r esm -r dotenv/config ./modules/node_modules/@frogpond/ccc-server/index.js",
     "stolaf-college": "env INSTITUTION=stolaf-college yarn start",
     "carleton-college": "env INSTITUTION=carleton-college yarn start",
     "test": "./scripts/smoke-test.sh",

--- a/scripts/docker-version.sh
+++ b/scripts/docker-version.sh
@@ -1,0 +1,12 @@
+get_docker_version() {
+	# e.g. Docker version 20.10.17, build 100c701
+	long_version="$(docker --version)"
+
+	# remove 'Docker version' text, commmas, and whitespace
+	short_version="$(echo $long_version | sed -e 's/Docker version//g' -e 's/,//g' | xargs)"
+
+	# e.g. 20.10.17 build 100c701
+	echo "$short_version"
+}
+
+get_docker_version


### PR DESCRIPTION
## Context 
This PR adds a script to grab the docker version and build info and pass it on to our user agent header.

If we do not want this:
  - We can revert the earlier addition to #641 which added docker in the header.
  - This PR is a place for discussion to the user agent values.

## Changes
**(current)** Diff prior to #641 
```diff
-ccc-server/1.0.0 (docker, node 10)
+ccc-server/0.1.0 (docker 20.10.17 node 17.0.1)
```

**(proposed)** Diff comparing #641 to this PR
```diff
-ccc-server/0.1.0 (docker 20.10.17 node 17.0.1)
+ccc-server/0.1.0 (docker 20.10.17 build 100c701; node 17.0.1)
```

--- 

- Follow-up to #641
- Format inspired by a comment on https://github.com/frog-pond/ccc-server/issues/34#issuecomment-386063578