### PR TITLE
remove docker version from user agent

### DIFF
--- a/modules/node_modules/@frogpond/ccc-lib/http.js
+++ b/modules/node_modules/@frogpond/ccc-lib/http.js
@@ -1,6 +1,6 @@
 import got from 'got'
 
-export const USER_AGENT = `ccc-server/0.1.0 (docker 20.10.17; node ${process.versions.node})`
+export const USER_AGENT = `ccc-server/0.1.0 (node ${process.versions.node})`
 
 export const get = (url, opts) =>
 	got(url, Object.assign({headers: {'User-Agent': USER_AGENT}}, opts))


### PR DESCRIPTION
Removes anything to do with docker and its version from the server's user agent.

- Follow-up to #645 