### PR TITLE
Convert frog-pond/ccc-server to GitHub Actions

### DIFF
--- a/.github/workflows/cron_weekly.yml
+++ b/.github/workflows/cron_weekly.yml
@@ -1,0 +1,50 @@
+name: frog-pond/ccc-server/cron_weekly
+on:
+  schedule:
+  - cron: 0 0 * * 1
+#   # 'filters' was not transformed because there is no suitable equivalent in GitHub Actions
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    container:
+      image: docker.io/circleci/node:10
+    env:
+      LOCAL_NAME: frogpond/ccc-server
+      DEST_NAME: docker.io/frogpond/ccc-server
+    steps:
+    - uses: actions/checkout@v2
+#     # 'setup_remote_docker' was not transformed because there is no suitable equivalent in GitHub Actions
+    - name: List docker images
+      run: docker images -a
+    - name: Build docker image
+      run: docker build --cache-from="$(docker images -a -q)" -t "$LOCAL_NAME:${{ github.sha }}" .
+    - name: Dump image to cachable .tar file
+      run: docker save "$LOCAL_NAME:${{ github.sha }}" > /tmp/image.tar
+    - name: save_cache
+      uses: actions/cache@v2
+      with:
+        path: "/tmp/image.tar"
+        key: docker--{{ arch }}-{{ .Branch }}-{{ .Revision }}
+  lint:
+    runs-on: ubuntu-latest
+    container:
+      image: docker.io/circleci/node:10
+    env:
+      LOCAL_NAME: frogpond/ccc-server
+      DEST_NAME: docker.io/frogpond/ccc-server
+    steps:
+    - uses: actions/checkout@v2
+    - run: yarn
+    - run: yarn run lint
+    - run: yarn run p && git diff --exit-code
+  test:
+    runs-on: ubuntu-latest
+    container:
+      image: docker.io/circleci/node:10
+    env:
+      LOCAL_NAME: frogpond/ccc-server
+      DEST_NAME: docker.io/frogpond/ccc-server
+    steps:
+    - uses: actions/checkout@v2
+    - run: yarn
+    - run: yarn test

--- a/.github/workflows/on_branch_commit.yml
+++ b/.github/workflows/on_branch_commit.yml
@@ -1,0 +1,48 @@
+name: frog-pond/ccc-server/on_branch_commit
+on:
+  push:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    container:
+      image: docker.io/circleci/node:10
+    env:
+      LOCAL_NAME: frogpond/ccc-server
+      DEST_NAME: docker.io/frogpond/ccc-server
+    steps:
+    - uses: actions/checkout@v2
+#     # 'setup_remote_docker' was not transformed because there is no suitable equivalent in GitHub Actions
+    - name: List docker images
+      run: docker images -a
+    - name: Build docker image
+      run: docker build --cache-from="$(docker images -a -q)" -t "$LOCAL_NAME:${{ github.sha }}" .
+    - name: Dump image to cachable .tar file
+      run: docker save "$LOCAL_NAME:${{ github.sha }}" > /tmp/image.tar
+    - name: save_cache
+      uses: actions/cache@v2
+      with:
+        path: "/tmp/image.tar"
+        key: docker--{{ arch }}-{{ .Branch }}-{{ .Revision }}
+  lint:
+    runs-on: ubuntu-latest
+    container:
+      image: docker.io/circleci/node:10
+    env:
+      LOCAL_NAME: frogpond/ccc-server
+      DEST_NAME: docker.io/frogpond/ccc-server
+    steps:
+    - uses: actions/checkout@v2
+    - run: yarn
+    - run: yarn run lint
+    - run: yarn run p && git diff --exit-code
+  test:
+    runs-on: ubuntu-latest
+    container:
+      image: docker.io/circleci/node:10
+    env:
+      LOCAL_NAME: frogpond/ccc-server
+      DEST_NAME: docker.io/frogpond/ccc-server
+    steps:
+    - uses: actions/checkout@v2
+    - run: yarn
+    - run: yarn test

--- a/.github/workflows/on_master_commit.yml
+++ b/.github/workflows/on_master_commit.yml
@@ -1,0 +1,109 @@
+name: frog-pond/ccc-server/on_master_commit
+on:
+  push:
+jobs:
+  build:
+    if: contains('refs/heads/master', github.ref) && ${{ !contains('refs/heads//.*/', github.ref) }}
+    runs-on: ubuntu-latest
+    container:
+      image: docker.io/circleci/node:10
+    env:
+      LOCAL_NAME: frogpond/ccc-server
+      DEST_NAME: docker.io/frogpond/ccc-server
+    steps:
+    - uses: actions/checkout@v2
+#     # 'setup_remote_docker' was not transformed because there is no suitable equivalent in GitHub Actions
+    - name: List docker images
+      run: docker images -a
+    - name: Build docker image
+      run: docker build --cache-from="$(docker images -a -q)" -t "$LOCAL_NAME:${{ github.sha }}" .
+    - name: Dump image to cachable .tar file
+      run: docker save "$LOCAL_NAME:${{ github.sha }}" > /tmp/image.tar
+    - name: save_cache
+      uses: actions/cache@v2
+      with:
+        path: "/tmp/image.tar"
+        key: docker--{{ arch }}-{{ .Branch }}-{{ .Revision }}
+  lint:
+    if: contains('refs/heads/master', github.ref) && ${{ !contains('refs/heads//.*/', github.ref) }}
+    runs-on: ubuntu-latest
+    container:
+      image: docker.io/circleci/node:10
+    env:
+      LOCAL_NAME: frogpond/ccc-server
+      DEST_NAME: docker.io/frogpond/ccc-server
+    steps:
+    - uses: actions/checkout@v2
+    - run: yarn
+    - run: yarn run lint
+    - run: yarn run p && git diff --exit-code
+  test:
+    if: contains('refs/heads/master', github.ref) && ${{ !contains('refs/heads//.*/', github.ref) }}
+    runs-on: ubuntu-latest
+    container:
+      image: docker.io/circleci/node:10
+    env:
+      LOCAL_NAME: frogpond/ccc-server
+      DEST_NAME: docker.io/frogpond/ccc-server
+    steps:
+    - uses: actions/checkout@v2
+    - run: yarn
+    - run: yarn test
+  deploy-docker:
+    if: contains('refs/heads/master', github.ref) && ${{ !contains('refs/heads//.*/', github.ref) }}
+    runs-on: ubuntu-latest
+    container:
+      image: docker.io/circleci/node:10
+    needs:
+    - lint
+    - test
+    - build
+    env:
+      LOCAL_NAME: frogpond/ccc-server
+      DEST_NAME: docker.io/frogpond/ccc-server
+      DOCKER_PASSWORD:
+      DOCKER_USERNAME:
+    steps:
+    - uses: actions/checkout@v2
+#     # 'setup_remote_docker' was not transformed because there is no suitable equivalent in GitHub Actions
+    - name: restore_cache
+      uses: actions/cache@v2
+      with:
+        key: docker--{{ arch }}-{{ .Branch }}-{{ .Revision }}
+        restore-keys: |-
+          docker--{{ arch }}-{{ .Branch }}-{{ .Revision }}
+          docker--{{ arch }}-{{ .Branch }}
+          docker--{{ arch }}
+    - name: Load from cache if possible
+      run: |-
+        if test -r /tmp/image.tar; then
+          echo "Loading from /tmp/image.tar"
+          docker load -qi /tmp/image.tar
+        else
+          echo "missing /tmp/image.tar; failing the build"
+          exit 1
+        fi
+    - run: docker login -u "$DOCKER_USERNAME" -p "$DOCKER_PASSWORD"
+    - name: Push to Docker Hub
+      run: |-
+        image_id="$(docker images -q "$LOCAL_NAME:${{ github.sha }}")"
+        echo "image_id: $image_id"
+        if [ -z $image_id ]; then
+          echo "could not find docker image to load; exiting"
+          exit 1
+        fi
+        echo "${{ github.ref }}: ${{ github.ref }}" "${{ github.ref }}: ${{ github.ref }}"
+        if [[ ${{ github.ref }} = master ]]; then
+          docker_tag="$DEST_NAME:HEAD"
+        elif [[ ${{ github.ref }} ]]; then
+          docker_tag="$DEST_NAME:${{ github.ref }}"
+        elif [[ ${{ github.ref }} ]]; then
+          docker_tag="$DEST_NAME:${{ github.ref }}"
+        fi
+        echo "docker_tag: $docker_tag"
+        docker tag "$image_id" "$docker_tag"
+        docker push "$docker_tag"
+        if [[ ${{ github.ref }} ]]; then
+          docker tag "$image_id" "$DEST_NAME:latest"
+          docker push "$DEST_NAME:latest"
+        fi

--- a/.github/workflows/on_tag.yml
+++ b/.github/workflows/on_tag.yml
@@ -1,0 +1,109 @@
+name: frog-pond/ccc-server/on_tag
+on:
+  push:
+jobs:
+  build:
+    if: ${{ !contains('refs/heads//.*/', github.ref) }}
+    runs-on: ubuntu-latest
+    container:
+      image: docker.io/circleci/node:10
+    env:
+      LOCAL_NAME: frogpond/ccc-server
+      DEST_NAME: docker.io/frogpond/ccc-server
+    steps:
+    - uses: actions/checkout@v2
+#     # 'setup_remote_docker' was not transformed because there is no suitable equivalent in GitHub Actions
+    - name: List docker images
+      run: docker images -a
+    - name: Build docker image
+      run: docker build --cache-from="$(docker images -a -q)" -t "$LOCAL_NAME:${{ github.sha }}" .
+    - name: Dump image to cachable .tar file
+      run: docker save "$LOCAL_NAME:${{ github.sha }}" > /tmp/image.tar
+    - name: save_cache
+      uses: actions/cache@v2
+      with:
+        path: "/tmp/image.tar"
+        key: docker--{{ arch }}-{{ .Branch }}-{{ .Revision }}
+  lint:
+    if: ${{ !contains('refs/heads//.*/', github.ref) }}
+    runs-on: ubuntu-latest
+    container:
+      image: docker.io/circleci/node:10
+    env:
+      LOCAL_NAME: frogpond/ccc-server
+      DEST_NAME: docker.io/frogpond/ccc-server
+    steps:
+    - uses: actions/checkout@v2
+    - run: yarn
+    - run: yarn run lint
+    - run: yarn run p && git diff --exit-code
+  test:
+    if: ${{ !contains('refs/heads//.*/', github.ref) }}
+    runs-on: ubuntu-latest
+    container:
+      image: docker.io/circleci/node:10
+    env:
+      LOCAL_NAME: frogpond/ccc-server
+      DEST_NAME: docker.io/frogpond/ccc-server
+    steps:
+    - uses: actions/checkout@v2
+    - run: yarn
+    - run: yarn test
+  deploy-docker:
+    if: ${{ !contains('refs/heads//.*/', github.ref) }}
+    runs-on: ubuntu-latest
+    container:
+      image: docker.io/circleci/node:10
+    needs:
+    - lint
+    - test
+    - build
+    env:
+      LOCAL_NAME: frogpond/ccc-server
+      DEST_NAME: docker.io/frogpond/ccc-server
+      DOCKER_PASSWORD:
+      DOCKER_USERNAME:
+    steps:
+    - uses: actions/checkout@v2
+#     # 'setup_remote_docker' was not transformed because there is no suitable equivalent in GitHub Actions
+    - name: restore_cache
+      uses: actions/cache@v2
+      with:
+        key: docker--{{ arch }}-{{ .Branch }}-{{ .Revision }}
+        restore-keys: |-
+          docker--{{ arch }}-{{ .Branch }}-{{ .Revision }}
+          docker--{{ arch }}-{{ .Branch }}
+          docker--{{ arch }}
+    - name: Load from cache if possible
+      run: |-
+        if test -r /tmp/image.tar; then
+          echo "Loading from /tmp/image.tar"
+          docker load -qi /tmp/image.tar
+        else
+          echo "missing /tmp/image.tar; failing the build"
+          exit 1
+        fi
+    - run: docker login -u "$DOCKER_USERNAME" -p "$DOCKER_PASSWORD"
+    - name: Push to Docker Hub
+      run: |-
+        image_id="$(docker images -q "$LOCAL_NAME:${{ github.sha }}")"
+        echo "image_id: $image_id"
+        if [ -z $image_id ]; then
+          echo "could not find docker image to load; exiting"
+          exit 1
+        fi
+        echo "${{ github.ref }}: ${{ github.ref }}" "${{ github.ref }}: ${{ github.ref }}"
+        if [[ ${{ github.ref }} = master ]]; then
+          docker_tag="$DEST_NAME:HEAD"
+        elif [[ ${{ github.ref }} ]]; then
+          docker_tag="$DEST_NAME:${{ github.ref }}"
+        elif [[ ${{ github.ref }} ]]; then
+          docker_tag="$DEST_NAME:${{ github.ref }}"
+        fi
+        echo "docker_tag: $docker_tag"
+        docker tag "$image_id" "$docker_tag"
+        docker push "$docker_tag"
+        if [[ ${{ github.ref }} ]]; then
+          docker tag "$image_id" "$DEST_NAME:latest"
+          docker push "$DEST_NAME:latest"
+        fi


### PR DESCRIPTION
Pipeline migrated from [CircleCI](https://app.circleci.com/pipelines/github/frog-pond/ccc-server) 🎉

- Closes #643

## Manual steps

Perform the follow steps to complete the migration:

### frog-pond/ccc-server/on_master_commit
- [ ] Ensure environment variable is updated: `DOCKER_PASSWORD`
- [ ] Ensure environment variable is updated: `DOCKER_USERNAME`

### frog-pond/ccc-server/on_tag
- [ ] Ensure environment variable is updated: `DOCKER_PASSWORD`
- [ ] Ensure environment variable is updated: `DOCKER_USERNAME`

---

What I ran to generate this PR:

```sh
gh actions-importer migrate circle-ci \
    --target-url http://github.com/frog-pond/ccc-server \
    --output-dir ./output/ \
    --source-file-path ./.circleci/config.yml \
    --circle-ci-organization frog-pond \
    --circle-ci-project ccc-server \
    --credentials-file credentials.yml \
    --no-telemetry

[2022-11-16 17:51:38] Logs: './output/log/valet-20221116-175138.log'
[2022-11-16 17:51:46] Pull request: 'https://github.com/frog-pond/ccc-server/pull/650'
```

with a `credentials.yml` file

- Note: The GitHub personal access token used below needs the `read:packages` scope. The [new way (beta)](https://github.com/settings/tokens/new) of creating tokens does not make it obvious about how to provide that scope, so I opted to create a token[ the classic way](https://github.com/settings/tokens) which explicitly lists it.

```yml
- url: https://github.com
  access_token: GH_AT
- url: https://circleci.com
  access_token: CIRCLE_AT
```