### PR TITLE
ccc-lib: Remove unnecessary `node` piece from the user-agent

### DIFF
--- a/modules/node_modules/@frogpond/ccc-lib/http.js
+++ b/modules/node_modules/@frogpond/ccc-lib/http.js
@@ -1,6 +1,6 @@
 import got from 'got'
 
-export const USER_AGENT = `ccc-server/0.1.0 (node ${process.versions.node})`
+export const USER_AGENT = 'ccc-server/0.1.0'
 
 export const get = (url, opts) =>
 	got(url, Object.assign({headers: {'User-Agent': USER_AGENT}}, opts))


### PR DESCRIPTION
Remove the `(node <version>)` part of the User-Agent. This was not strictly required.

Something along the way from us to BonApp (i.e. Cloudflare) seems to be blocking us based on the keyword `node`.

- `asdf` -> 200 OK
- `asdf node` -> `error code: 1020`, `HTTP/1.1 403 Forbidden`
- `ccc-server/0.1.0` -> 200 OK
- `ccc-server/0.1.0 (node asdf)` -> `error code: 1020`, `HTTP/1.1 403 Forbidden`