### PR TITLE
Stop streams endoints from incorrectly caching

### DIFF
--- a/modules/node_modules/@frogpond/ccci-stolaf-college/v1/streams/index.js
+++ b/modules/node_modules/@frogpond/ccci-stolaf-college/v1/streams/index.js
@@ -1,8 +1,5 @@
 import {get, ONE_HOUR} from '@frogpond/ccc-lib'
-import mem from 'mem'
 import moment from 'moment-timezone'
-
-const GET = mem(get, {maxAge: ONE_HOUR})
 
 export async function getStreams({streamClass, sort, dateFrom, dateTo}) {
 	const params = {
@@ -15,7 +12,7 @@ export async function getStreams({streamClass, sort, dateFrom, dateTo}) {
 	}
 
 	const url = 'https://www.stolaf.edu/multimedia/api/collection'
-	const data = await GET(url, {json: true, query: params}).then(
+	const data = await get(url, {json: true, query: params}).then(
 		(resp) => resp.body,
 	)
 	const processed = data.results.map((stream) => {


### PR DESCRIPTION
- Removes `mem` from the streams endpoint.
- Closes #694 