### PR TITLE
add v1 endpoints to /routes

### DIFF
--- a/modules/node_modules/@frogpond/ccci-stolaf-college/v1/index.js
+++ b/modules/node_modules/@frogpond/ccci-stolaf-college/v1/index.js
@@ -115,4 +115,16 @@ api.get('/printing/color-printers', printing.colorPrinters)
 // utilities
 api.get('/util/html-to-md', util.htmlToMarkdown)
 
+// sitemap
+api.get('/routes', (ctx) => {
+    const leadingVersionRegex = /\/v[0-9]\//
+    ctx.body = api.stack.map(layer => ({
+        path: layer.path,
+        displayName: layer.path.split(leadingVersionRegex).slice(1).join(),
+        params: layer.paramNames.map(param => param.name)
+    })).sort((a, b) =>
+        a.path.localeCompare(b.path),
+    )
+})
+
 export {api}


### PR DESCRIPTION
Part of the [internal tooling effort](https://github.com/orgs/StoDevX/projects/5?pane=issue&itemId=18626786).

This exports the list of v1 routes [for consumer usage](https://github.com/StoDevX/AAO-React-Native/pull/7091) at `/v1/routes`.