### PR TITLE
calendar fixes

### DIFF
--- a/source/calendar/ical.js
+++ b/source/calendar/ical.js
@@ -41,7 +41,7 @@ function convertEvents(data, now = moment()) {
 }
 
 export async function ical(url, {onlyFuture = true} = {}, now = moment()) {
-	let body = await get(url).text()
+	let body = await get(url, {headers: {accept: 'text/calendar'}}).text()
 
 	let comp = InternetCalendar.Component.fromString(body)
 	let events = comp

--- a/source/calendar/types.js
+++ b/source/calendar/types.js
@@ -12,6 +12,7 @@ export const Event = z.object({
 	endTime: z.string().datetime(),
 	title: z.string(),
 	description: z.string(),
+	location: z.string().default(''),
 	isOngoing: z.boolean(),
 	links: z.array(z.unknown()),
 	config: EventConfig,

--- a/source/calendar/types.js
+++ b/source/calendar/types.js
@@ -3,7 +3,7 @@ import {z} from 'zod'
 const EventConfig = z.object({
 	startTime: z.boolean(),
 	endTime: z.boolean(),
-	subtitle: z.union([z.literal('location')]),
+	subtitle: z.union([z.literal('location'), z.literal('description')]),
 })
 
 export const Event = z.object({

--- a/source/ccci-carleton-college/v1/calendar.js
+++ b/source/ccci-carleton-college/v1/calendar.js
@@ -32,7 +32,7 @@ export async function cave(ctx) {
 	ctx.cacheControl(ONE_MINUTE)
 
 	let url =
-		'https://www.carleton.edu/student/orgs/cave/calendar/?loadFeed=calendar&stamp=1714844429\n'
+		'https://www.carleton.edu/student/orgs/cave/calendar/?loadFeed=calendar'
 	ctx.body = await getInternetCalendar(url)
 }
 


### PR DESCRIPTION
- ask for `text/calendar` when getting ical files
- "fix" url for carleton the-cave (it still returns html instead of ICS, but at least the URL is valid now!)
- add new allowed subtitle format: `description`
- add missing "location" property in event outputs: fixes the detail crash, I expect
