### PR TITLE
hawken/avoid caching menu errors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@sentry/profiling-node": "^7.113.0",
         "@sentry/utils": "^7.113.0",
         "dotenv": "16.4.5",
+        "expiry-map": "^2.0.0",
         "get-urls": "12.1.0",
         "html-entities": "2.5.2",
         "ical.js": "^2.0.1",
@@ -33,6 +34,7 @@
         "moment-timezone": "0.5.45",
         "normalize-url": "8.0.1",
         "p-map": "7.0.2",
+        "p-memoize": "^7.1.1",
         "turndown": "7.1.3",
         "zod": "^3.23.6"
       },
@@ -964,6 +966,17 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/expiry-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/expiry-map/-/expiry-map-2.0.0.tgz",
+      "integrity": "sha512-K1I5wJe2fiqjyUZf/xhxwTpaopw3F+19DsO7Oggl20+3SVTXDIevVRJav0aBMfposQdkl2E4+gnuOKd3j2X0sA==",
+      "dependencies": {
+        "map-age-cleaner": "^0.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -1869,6 +1882,17 @@
         "node": ">=10"
       }
     },
+    "node_modules/map-age-cleaner": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.2.0.tgz",
+      "integrity": "sha512-AvxTC6id0fzSf6OyNBTp1syyCuKO7nOJvHgYlhT0Qkkjvk40zZo+av3ayVgXlxnF/DxEzEfY9mMdd7FHsd+wKQ==",
+      "dependencies": {
+        "p-defer": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=7.6"
+      }
+    },
     "node_modules/media-typer": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
@@ -1916,6 +1940,17 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/mimic-fn": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
+      "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/mimic-function": {
@@ -2047,6 +2082,14 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/p-defer": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
+      "integrity": "sha512-wB3wfAxZpk2AzOfUMJNL+d36xothRSyj8EXOa4f6GMqYDN9BJaaSISbsk+wS9abmnebVw95C2Kb5t85UmpCxuw==",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/p-limit": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
@@ -2086,6 +2129,21 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-memoize": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/p-memoize/-/p-memoize-7.1.1.tgz",
+      "integrity": "sha512-DZ/bONJILHkQ721hSr/E9wMz5Am/OTJ9P6LhLFo2Tu+jL8044tgc9LwHO8g4PiaYePnlVVRAJcKmgy8J9MVFrA==",
+      "dependencies": {
+        "mimic-fn": "^4.0.0",
+        "type-fest": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/p-memoize?sponsor=1"
       }
     },
     "node_modules/parent-module": {
@@ -2572,6 +2630,17 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/type-fest": {
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-3.13.1.tgz",
+      "integrity": "sha512-tLq3bSNx+xSpwvAJnzrK0Ep5CLNWjvFTOp71URMaAEWBfRb9nnJiBoUe0tF8bI4ZFO3omgBR6NvnbzVUT3Ly4g==",
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/type-is": {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@sentry/profiling-node": "^7.113.0",
     "@sentry/utils": "^7.113.0",
     "dotenv": "16.4.5",
+    "expiry-map": "^2.0.0",
     "get-urls": "12.1.0",
     "html-entities": "2.5.2",
     "ical.js": "^2.0.1",
@@ -50,6 +51,7 @@
     "moment-timezone": "0.5.45",
     "normalize-url": "8.0.1",
     "p-map": "7.0.2",
+    "p-memoize": "^7.1.1",
     "turndown": "7.1.3",
     "zod": "^3.23.6"
   },

--- a/source/ccc-lib/cache.js
+++ b/source/ccc-lib/cache.js
@@ -1,0 +1,6 @@
+import ExpiryMap from 'expiry-map'
+import {ONE_DAY, ONE_HOUR, ONE_MINUTE} from './constants.js'
+
+export const ONE_MINUTE_CACHE = new ExpiryMap(ONE_MINUTE)
+export const ONE_HOUR_CACHE = new ExpiryMap(ONE_HOUR)
+export const ONE_DAY_CACHE = new ExpiryMap(ONE_DAY)

--- a/source/ccci-carleton-college/v1/calendar.js
+++ b/source/ccci-carleton-college/v1/calendar.js
@@ -1,10 +1,13 @@
 import {googleCalendar} from '../../calendar/google.js'
 import {ical} from '../../calendar/ical.js'
 import {ONE_MINUTE} from '../../ccc-lib/constants.js'
-import mem from 'memoize'
+import pMemoize from 'p-memoize'
+import {ONE_MINUTE_CACHE} from '../../ccc-lib/cache.js'
 
-export const getGoogleCalendar = mem(googleCalendar, {maxAge: ONE_MINUTE})
-export const getInternetCalendar = mem(ical, {maxAge: ONE_MINUTE})
+export const getGoogleCalendar = pMemoize(googleCalendar, {
+	cache: ONE_MINUTE_CACHE,
+})
+export const getInternetCalendar = pMemoize(ical, {cache: ONE_MINUTE_CACHE})
 
 export async function google(ctx) {
 	ctx.cacheControl(ONE_MINUTE)

--- a/source/ccci-carleton-college/v1/contacts.js
+++ b/source/ccci-carleton-college/v1/contacts.js
@@ -1,15 +1,11 @@
 import {get} from '../../ccc-lib/http.js'
 import {ONE_HOUR} from '../../ccc-lib/constants.js'
-import mem from 'memoize'
 import {GH_PAGES} from './gh-pages.js'
+import pMemoize from 'p-memoize'
+import {ONE_HOUR_CACHE} from '../../ccc-lib/cache.js'
 
-const GET = mem(get, {maxAge: ONE_HOUR})
-
-let url = GH_PAGES('contact-info.json')
-
-export function getContacts() {
-	return GET(url).json()
-}
+const _getContacts = () => get(GH_PAGES('contact-info.json')).json()
+export const getContacts = pMemoize(_getContacts, {cache: ONE_HOUR_CACHE})
 
 export async function contacts(ctx) {
 	ctx.cacheControl(ONE_HOUR)

--- a/source/ccci-carleton-college/v1/dictionary.js
+++ b/source/ccci-carleton-college/v1/dictionary.js
@@ -1,18 +1,15 @@
 import {get} from '../../ccc-lib/http.js'
 import {ONE_HOUR} from '../../ccc-lib/constants.js'
-import mem from 'memoize'
 import {GH_PAGES} from './gh-pages.js'
+import pMemoize from 'p-memoize'
+import {ONE_HOUR_CACHE} from '../../ccc-lib/cache.js'
 
-const GET = mem(get, {maxAge: ONE_HOUR})
-
-let url = GH_PAGES('dictionary-carls.json')
-
-export function getDictionary() {
-	return GET(url).json()
-}
+const _getDictionary = () => get(GH_PAGES('dictionary-carls.json')).json()
+export const getDictionary = pMemoize(_getDictionary, {
+	cache: ONE_HOUR_CACHE,
+})
 
 export async function dictionary(ctx) {
 	ctx.cacheControl(ONE_HOUR)
-
 	ctx.body = await getDictionary()
 }

--- a/source/ccci-carleton-college/v1/menu.js
+++ b/source/ccci-carleton-college/v1/menu.js
@@ -1,16 +1,16 @@
 import {get} from '../../ccc-lib/http.js'
-import {ONE_DAY, ONE_HOUR} from '../../ccc-lib/constants.js'
+import {ONE_HOUR} from '../../ccc-lib/constants.js'
 import * as bonapp from '../../menus-bonapp/index.js'
-import mem from 'memoize'
 import {GH_PAGES} from './gh-pages.js'
+import pMemoize from 'p-memoize'
+import {ONE_DAY_CACHE, ONE_HOUR_CACHE} from '../../ccc-lib/cache.js'
 
-const pauseMenuUrl = GH_PAGES('pause-menu.json')
-const GET_DAY = mem(get, {maxAge: ONE_DAY})
-export const getPauseMenu = () => GET_DAY(pauseMenuUrl).json()
+const _getPauseMenu = () => get(GH_PAGES('pause-menu.json')).json()
+export const getPauseMenu = pMemoize(_getPauseMenu, {cache: ONE_DAY_CACHE})
 
-const getMenu = mem(bonapp.menu, {maxAge: ONE_HOUR})
-const getInfo = mem(bonapp.cafe, {maxAge: ONE_HOUR})
-const getNutrition = mem(bonapp.nutrition, {maxAge: ONE_HOUR})
+const getMenu = pMemoize(bonapp.menu, {cache: ONE_HOUR_CACHE})
+const getInfo = pMemoize(bonapp.cafe, {cache: ONE_HOUR_CACHE})
+const getNutrition = pMemoize(bonapp.nutrition, {cache: ONE_HOUR_CACHE})
 
 export const CAFE_URLS = {
 	stav: 'https://stolaf.cafebonappetit.com/cafe/stav-hall/',
@@ -36,132 +36,110 @@ export const CAFE_ID_TO_URL = {
 
 export async function pauseMenu(ctx) {
 	ctx.cacheControl(ONE_HOUR)
-
 	ctx.body = await getPauseMenu()
 }
 
 export async function bonAppMenu(ctx) {
 	ctx.cacheControl(ONE_HOUR)
-
 	ctx.body = await getMenu(CAFE_URLS[CAFE_ID_TO_URL[ctx.params.cafeId]])
 }
 
 export async function bonAppCafe(ctx) {
 	ctx.cacheControl(ONE_HOUR)
-
 	ctx.body = await getInfo(CAFE_URLS[CAFE_ID_TO_URL[ctx.params.cafeId]])
 }
 
 export async function bonAppNutrition(ctx) {
 	ctx.cacheControl(ONE_HOUR)
-
 	ctx.body = await getNutrition(ctx.params.itemId)
 }
 
 export async function stavCafe(ctx) {
 	ctx.cacheControl(ONE_HOUR)
-
 	ctx.body = await getInfo(CAFE_URLS.stav)
 }
 
 export async function stavMenu(ctx) {
 	ctx.cacheControl(ONE_HOUR)
-
 	ctx.body = await getMenu(CAFE_URLS.stav)
 }
 
 export async function cageCafe(ctx) {
 	ctx.cacheControl(ONE_HOUR)
-
 	ctx.body = await getInfo(CAFE_URLS.cage)
 }
 
 export async function cageMenu(ctx) {
 	ctx.cacheControl(ONE_HOUR)
-
 	ctx.body = await getMenu(CAFE_URLS.cage)
 }
 
 export async function kingsRoomCafe(ctx) {
 	ctx.cacheControl(ONE_HOUR)
-
 	ctx.body = await getInfo(CAFE_URLS.kingsRoom)
 }
 
 export async function kingsRoomMenu(ctx) {
 	ctx.cacheControl(ONE_HOUR)
-
 	ctx.body = await getMenu(CAFE_URLS.kingsRoom)
 }
 
 export async function caveCafe(ctx) {
 	ctx.cacheControl(ONE_HOUR)
-
 	ctx.body = await getInfo(CAFE_URLS.cave)
 }
 
 export async function caveMenu(ctx) {
 	ctx.cacheControl(ONE_HOUR)
-
 	ctx.body = await getMenu(CAFE_URLS.cave)
 }
 
 export async function burtonCafe(ctx) {
 	ctx.cacheControl(ONE_HOUR)
-
 	ctx.body = await getInfo(CAFE_URLS.burton)
 }
 
 export async function burtonMenu(ctx) {
 	ctx.cacheControl(ONE_HOUR)
-
 	ctx.body = await getMenu(CAFE_URLS.burton)
 }
 
 export async function ldcCafe(ctx) {
 	ctx.cacheControl(ONE_HOUR)
-
 	ctx.body = await getInfo(CAFE_URLS.ldc)
 }
 
 export async function ldcMenu(ctx) {
 	ctx.cacheControl(ONE_HOUR)
-
 	ctx.body = await getMenu(CAFE_URLS.ldc)
 }
 
 export async function saylesCafe(ctx) {
 	ctx.cacheControl(ONE_HOUR)
-
 	ctx.body = await getInfo(CAFE_URLS.sayles)
 }
 
 export async function saylesMenu(ctx) {
 	ctx.cacheControl(ONE_HOUR)
-
 	ctx.body = await getMenu(CAFE_URLS.sayles)
 }
 
 export async function weitzCafe(ctx) {
 	ctx.cacheControl(ONE_HOUR)
-
 	ctx.body = await getInfo(CAFE_URLS.weitz)
 }
 
 export async function weitzMenu(ctx) {
 	ctx.cacheControl(ONE_HOUR)
-
 	ctx.body = await getMenu(CAFE_URLS.weitz)
 }
 
 export async function schulzeCafe(ctx) {
 	ctx.cacheControl(ONE_HOUR)
-
 	ctx.body = await getInfo(CAFE_URLS.schulze)
 }
 
 export async function schulzeMenu(ctx) {
 	ctx.cacheControl(ONE_HOUR)
-
 	ctx.body = await getMenu(CAFE_URLS.schulze)
 }

--- a/source/ccci-stolaf-college/v1/hours.js
+++ b/source/ccci-stolaf-college/v1/hours.js
@@ -1,18 +1,15 @@
 import {get} from '../../ccc-lib/http.js'
 import {ONE_HOUR} from '../../ccc-lib/constants.js'
-import mem from 'memoize'
 import {GH_PAGES} from './gh-pages.js'
+import pMemoize from 'p-memoize'
+import {ONE_HOUR_CACHE} from '../../ccc-lib/cache.js'
 
-const GET = mem(get, {maxAge: ONE_HOUR})
-
-let url = GH_PAGES('building-hours.json')
-
-export function getBuildingHours() {
-	return GET(url).json()
-}
+const _getBuildingHours = () => get(GH_PAGES('building-hours.json')).json()
+export const getBuildingHours = pMemoize(_getBuildingHours, {
+	cache: ONE_HOUR_CACHE,
+})
 
 export async function buildingHours(ctx) {
 	ctx.cacheControl(ONE_HOUR)
-
 	ctx.body = await getBuildingHours()
 }

--- a/source/ccci-stolaf-college/v1/transit.js
+++ b/source/ccci-stolaf-college/v1/transit.js
@@ -1,13 +1,13 @@
 import {get} from '../../ccc-lib/http.js'
 import {ONE_HOUR} from '../../ccc-lib/constants.js'
-import mem from 'memoize'
 import {GH_PAGES} from './gh-pages.js'
+import pMemoize from 'p-memoize'
+import {ONE_HOUR_CACHE} from '../../ccc-lib/cache.js'
 
-const GET = mem(get, {maxAge: ONE_HOUR})
-
-export function getBus() {
-	return GET(GH_PAGES('bus-times.json')).json()
-}
+const _getBus = () => get(GH_PAGES('bus-times.json')).json()
+export const getBus = pMemoize(_getBus, {
+	cache: ONE_HOUR_CACHE,
+})
 
 export async function bus(ctx) {
 	ctx.cacheControl(ONE_HOUR)
@@ -15,9 +15,10 @@ export async function bus(ctx) {
 	ctx.body = await getBus()
 }
 
-export function getModes() {
-	return GET(GH_PAGES('transportation.json')).json()
-}
+const _getModes = () => get(GH_PAGES('transportation.json')).json()
+export const getModes = pMemoize(_getModes, {
+	cache: ONE_HOUR_CACHE,
+})
 
 export async function modes(ctx) {
 	ctx.cacheControl(ONE_HOUR)

--- a/source/menus-bonapp/index.js
+++ b/source/menus-bonapp/index.js
@@ -1,13 +1,10 @@
 import {get} from '../ccc-lib/http.js'
-import {ONE_MINUTE} from '../ccc-lib/constants.js'
 import {JSDOM, VirtualConsole} from 'jsdom'
 import * as Sentry from '@sentry/node'
 import pMemoize from 'p-memoize'
-import ExpiryMap from 'expiry-map'
 import {CafeMenuIsClosed, CafeMenuWithError, CustomCafe} from './helpers.js'
 import {BamcoCafeInfo, BamcoPageContents, CafeMenu} from './types.js'
-
-const cache = new ExpiryMap(ONE_MINUTE)
+import {ONE_HOUR_CACHE} from '../ccc-lib/cache.js'
 
 /**
  * @param {string} url
@@ -34,7 +31,7 @@ async function _getBonAppWebpage(url) {
 	})
 }
 
-const getBonAppWebpage = pMemoize(_getBonAppWebpage, {cache})
+const getBonAppWebpage = pMemoize(_getBonAppWebpage, {cache: ONE_HOUR_CACHE})
 
 /**
  * @param {string|URL} cafeUrl


### PR DESCRIPTION
- **add dep on p-memoize**
- **use p-memoize to cache the bonapp requests - p-memoize doesn't cache rejected promises**
- **add central one-{minute,hour,day} caches**
- **p-memoize carleton/calendar**
- **p-memoize carleton/contacts**
- **p-memoize carleton/convos**
- **p-memoize carleton/dictionary**
- **p-memoize carleton/menu**
- **p-memoize stolaf/hours**
- **p-memoize stolaf/transit**
- **fix menu caching again (from refactor)**
