### PR TITLE
Broken response streams

### DIFF
--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -49,6 +49,11 @@ for route in $(curl -s localhost:3000/v1/routes | jq -r '.[].path'); do
       continue
       ;;
 
+    "/v1/news/named/oleville")
+      echo "skip because oleville tends to break often and isn't worth testing"
+      continue
+      ;;
+
     *"/:"*)
       echo "skip because of parameter placeholders"
       continue

--- a/source/ccci-stolaf-college/v1/a-z.ts
+++ b/source/ccci-stolaf-college/v1/a-z.ts
@@ -5,8 +5,6 @@ import {GH_PAGES} from './gh-pages.js'
 import type {Context} from '../../ccc-server/context.js'
 import {z} from 'zod'
 
-const GET = mem(get, {maxAge: ONE_DAY})
-
 type StOlafAzResponseType = z.infer<typeof StOlafAzResponseSchema>
 const StOlafAzResponseSchema = z.object({
 	az_nav: z.object({
@@ -29,14 +27,16 @@ const AllAboutOlafExtraAzResponseSchema = z.object({
 	),
 })
 
-async function getOlafAtoZ() {
+const getOlafAtoZ = mem(async () => {
 	let url = 'https://wp.stolaf.edu/wp-json/site-data/sidebar/a-z'
-	return StOlafAzResponseSchema.parse(await GET(url).json())
-}
+	const response = await get(url)
+	return StOlafAzResponseSchema.parse(await response.json())
+}, {maxAge: ONE_DAY})
 
-async function getPagesAtoZ() {
-	return AllAboutOlafExtraAzResponseSchema.parse(await GET(GH_PAGES('a-to-z.json')).json())
-}
+const getPagesAtoZ = mem(async () => {
+	const response = await get(GH_PAGES('a-to-z.json'))
+	return AllAboutOlafExtraAzResponseSchema.parse(await response.json())
+}, {maxAge: ONE_DAY})
 
 // merge custom entries defined on GH pages with the fetched WP-JSON
 function combineResponses(

--- a/source/ccci-stolaf-college/v1/a-z.ts
+++ b/source/ccci-stolaf-college/v1/a-z.ts
@@ -27,16 +27,22 @@ const AllAboutOlafExtraAzResponseSchema = z.object({
 	),
 })
 
-const getOlafAtoZ = mem(async () => {
-	let url = 'https://wp.stolaf.edu/wp-json/site-data/sidebar/a-z'
-	const response = await get(url)
-	return StOlafAzResponseSchema.parse(await response.json())
-}, {maxAge: ONE_DAY})
+const getOlafAtoZ = mem(
+	async () => {
+		let url = 'https://wp.stolaf.edu/wp-json/site-data/sidebar/a-z'
+		const response = await get(url)
+		return StOlafAzResponseSchema.parse(await response.json())
+	},
+	{maxAge: ONE_DAY},
+)
 
-const getPagesAtoZ = mem(async () => {
-	const response = await get(GH_PAGES('a-to-z.json'))
-	return AllAboutOlafExtraAzResponseSchema.parse(await response.json())
-}, {maxAge: ONE_DAY})
+const getPagesAtoZ = mem(
+	async () => {
+		const response = await get(GH_PAGES('a-to-z.json'))
+		return AllAboutOlafExtraAzResponseSchema.parse(await response.json())
+	},
+	{maxAge: ONE_DAY},
+)
 
 // merge custom entries defined on GH pages with the fetched WP-JSON
 function combineResponses(

--- a/source/ccci-stolaf-college/v1/contacts.ts
+++ b/source/ccci-stolaf-college/v1/contacts.ts
@@ -4,10 +4,13 @@ import mem from 'memoize'
 import {GH_PAGES} from './gh-pages.js'
 import type {Context} from '../../ccc-server/context.js'
 
-const getContacts = mem(async () => {
-	const response = await get(GH_PAGES('contact-info.json'))
-	return response.json()
-}, {maxAge: ONE_DAY})
+const getContacts = mem(
+	async () => {
+		const response = await get(GH_PAGES('contact-info.json'))
+		return response.json()
+	},
+	{maxAge: ONE_DAY},
+)
 
 export async function contacts(ctx: Context) {
 	ctx.cacheControl(ONE_DAY)

--- a/source/ccci-stolaf-college/v1/contacts.ts
+++ b/source/ccci-stolaf-college/v1/contacts.ts
@@ -4,13 +4,10 @@ import mem from 'memoize'
 import {GH_PAGES} from './gh-pages.js'
 import type {Context} from '../../ccc-server/context.js'
 
-const GET = mem(get, {maxAge: ONE_DAY})
-
-let url = GH_PAGES('contact-info.json')
-
-export function getContacts() {
-	return GET(url).json()
-}
+const getContacts = mem(async () => {
+	const response = await get(GH_PAGES('contact-info.json'))
+	return response.json()
+}, {maxAge: ONE_DAY})
 
 export async function contacts(ctx: Context) {
 	ctx.cacheControl(ONE_DAY)

--- a/source/ccci-stolaf-college/v1/dictionary.ts
+++ b/source/ccci-stolaf-college/v1/dictionary.ts
@@ -4,10 +4,13 @@ import mem from 'memoize'
 import {GH_PAGES} from './gh-pages.js'
 import type {Context} from '../../ccc-server/context.js'
 
-const getDictionary = mem(async () => {
-	const response = await get(GH_PAGES('dictionary.json'))
-	return response.json()
-}, {maxAge: ONE_DAY})
+const getDictionary = mem(
+	async () => {
+		const response = await get(GH_PAGES('dictionary.json'))
+		return response.json()
+	},
+	{maxAge: ONE_DAY},
+)
 
 export async function dictionary(ctx: Context) {
 	ctx.cacheControl(ONE_DAY)

--- a/source/ccci-stolaf-college/v1/dictionary.ts
+++ b/source/ccci-stolaf-college/v1/dictionary.ts
@@ -4,13 +4,10 @@ import mem from 'memoize'
 import {GH_PAGES} from './gh-pages.js'
 import type {Context} from '../../ccc-server/context.js'
 
-const GET = mem(get, {maxAge: ONE_DAY})
-
-let url = GH_PAGES('dictionary.json')
-
-export function getDictionary() {
-	return GET(url).json()
-}
+const getDictionary = mem(async () => {
+	const response = await get(GH_PAGES('dictionary.json'))
+	return response.json()
+}, {maxAge: ONE_DAY})
 
 export async function dictionary(ctx: Context) {
 	ctx.cacheControl(ONE_DAY)

--- a/source/ccci-stolaf-college/v1/faqs.ts
+++ b/source/ccci-stolaf-college/v1/faqs.ts
@@ -4,13 +4,10 @@ import mem from 'memoize'
 import {GH_PAGES} from './gh-pages.js'
 import type {Context} from '../../ccc-server/context.js'
 
-const GET = mem(get, {maxAge: ONE_DAY})
-
-let url = GH_PAGES('faqs.json')
-
-export function getFaqs() {
-	return GET(url).json()
-}
+const getFaqs = mem(async () => {
+	const response = await get(GH_PAGES('faqs.json'))
+	return response.json()
+}, {maxAge: ONE_DAY})
 
 export async function faqs(ctx: Context) {
 	ctx.cacheControl(ONE_DAY)

--- a/source/ccci-stolaf-college/v1/faqs.ts
+++ b/source/ccci-stolaf-college/v1/faqs.ts
@@ -4,10 +4,13 @@ import mem from 'memoize'
 import {GH_PAGES} from './gh-pages.js'
 import type {Context} from '../../ccc-server/context.js'
 
-const getFaqs = mem(async () => {
-	const response = await get(GH_PAGES('faqs.json'))
-	return response.json()
-}, {maxAge: ONE_DAY})
+const getFaqs = mem(
+	async () => {
+		const response = await get(GH_PAGES('faqs.json'))
+		return response.json()
+	},
+	{maxAge: ONE_DAY},
+)
 
 export async function faqs(ctx: Context) {
 	ctx.cacheControl(ONE_DAY)

--- a/source/ccci-stolaf-college/v1/hours.ts
+++ b/source/ccci-stolaf-college/v1/hours.ts
@@ -4,13 +4,10 @@ import mem from 'memoize'
 import {GH_PAGES} from './gh-pages.js'
 import type {Context} from '../../ccc-server/context.js'
 
-const GET = mem(get, {maxAge: ONE_HOUR})
-
-let url = GH_PAGES('building-hours.json')
-
-export function getBuildingHours() {
-	return GET(url).json()
-}
+const getBuildingHours = mem(async () => {
+	const response = await get(GH_PAGES('building-hours.json'))
+	return response.json()
+}, {maxAge: ONE_HOUR})
 
 export async function buildingHours(ctx: Context) {
 	ctx.cacheControl(ONE_HOUR)

--- a/source/ccci-stolaf-college/v1/hours.ts
+++ b/source/ccci-stolaf-college/v1/hours.ts
@@ -4,10 +4,13 @@ import mem from 'memoize'
 import {GH_PAGES} from './gh-pages.js'
 import type {Context} from '../../ccc-server/context.js'
 
-const getBuildingHours = mem(async () => {
-	const response = await get(GH_PAGES('building-hours.json'))
-	return response.json()
-}, {maxAge: ONE_HOUR})
+const getBuildingHours = mem(
+	async () => {
+		const response = await get(GH_PAGES('building-hours.json'))
+		return response.json()
+	},
+	{maxAge: ONE_HOUR},
+)
 
 export async function buildingHours(ctx: Context) {
 	ctx.cacheControl(ONE_HOUR)

--- a/source/ccci-stolaf-college/v1/transit.ts
+++ b/source/ccci-stolaf-college/v1/transit.ts
@@ -4,10 +4,13 @@ import mem from 'memoize'
 import {GH_PAGES} from './gh-pages.js'
 import type {Context} from '../../ccc-server/context.js'
 
-const getBus = mem(async () => {
-	const response = await get(GH_PAGES('bus-times.json'))
-	return response.json()
-}, {maxAge: ONE_HOUR})
+const getBus = mem(
+	async () => {
+		const response = await get(GH_PAGES('bus-times.json'))
+		return response.json()
+	},
+	{maxAge: ONE_HOUR},
+)
 
 export async function bus(ctx: Context) {
 	ctx.cacheControl(ONE_HOUR)
@@ -15,10 +18,13 @@ export async function bus(ctx: Context) {
 	ctx.body = await getBus()
 }
 
-const getModes = mem(async () => {
-	const response = await get(GH_PAGES('transportation.json'))
-	return response.json()
-}, {maxAge: ONE_HOUR})
+const getModes = mem(
+	async () => {
+		const response = await get(GH_PAGES('transportation.json'))
+		return response.json()
+	},
+	{maxAge: ONE_HOUR},
+)
 
 export async function modes(ctx: Context) {
 	ctx.cacheControl(ONE_HOUR)

--- a/source/ccci-stolaf-college/v1/transit.ts
+++ b/source/ccci-stolaf-college/v1/transit.ts
@@ -4,11 +4,10 @@ import mem from 'memoize'
 import {GH_PAGES} from './gh-pages.js'
 import type {Context} from '../../ccc-server/context.js'
 
-const GET = mem(get, {maxAge: ONE_HOUR})
-
-export function getBus() {
-	return GET(GH_PAGES('bus-times.json')).json()
-}
+const getBus = mem(async () => {
+	const response = await get(GH_PAGES('bus-times.json'))
+	return response.json()
+}, {maxAge: ONE_HOUR})
 
 export async function bus(ctx: Context) {
 	ctx.cacheControl(ONE_HOUR)
@@ -16,9 +15,10 @@ export async function bus(ctx: Context) {
 	ctx.body = await getBus()
 }
 
-export function getModes() {
-	return GET(GH_PAGES('transportation.json')).json()
-}
+const getModes = mem(async () => {
+	const response = await get(GH_PAGES('transportation.json'))
+	return response.json()
+}, {maxAge: ONE_HOUR})
 
 export async function modes(ctx: Context) {
 	ctx.cacheControl(ONE_HOUR)


### PR DESCRIPTION
Response objects in ccc are being consumed more than once without being cloned first. If we are using the response body multiple times, which is a stream, it can't be read again, so we have issue.

 `*` denotes we have seen it error, check means this PR changes that

- [x] A-to-z `*`
- [ ] Calendar
- [x] Contacts `*`
- [x] Dictionary `*` 
- [x] FAQs `*`
- [x] Hours
- [ ] Jobs
- [ ] Menu `*` (in our smoke test)
- [ ] News
- [ ] Orgs
- [ ] Routes [dev only] `*`
- [x] Streams `*`
- [x] Transport

--- 

```sh
$ docker-compose logs

TypeError: Response.clone: Body has already been consumed.
    at webidl.errors.exception (node:internal/deps/undici/undici:3384:14)
    at _Response.clone (node:internal/deps/undici/undici:8883:31)
    at result.<computed> [as json] (file:///app/node_modules/ky/distribution/core/Ky.js:55:48)
    at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
    at async getOlafAtoZ (file:///app/dist/source/ccci-stolaf-college/v1/a-z.js:23:41)
    at async atoz (file:///app/dist/source/ccci-stolaf-college/v1/a-z.js:49:24)
    at async bodyParser (/app/node_modules/koa-bodyparser/index.js:78:5)
    at async etag (/app/node_modules/koa-etag/index.js:27:5)
    at async /app/node_modules/koa-conditional-get/index.js:15:5
    at async compressMiddleware (/app/node_modules/koa-compress/lib/index.js:56:5)
```

The assumption being that this could be triggered by another request, logging, middleware, or most likely our mem caching.

The issue being the memoized response will return the same Response object, leading to an error if we are trying to access something on it.

This is what I am thinking is happening
1. GET(url) makes the http request and returns a Response object
2. .json() consumes the body of the Response
3. Memoized GET(url) --> subsequent calls to GET(url).json() reuse the same Response object from first http call

I can point my physical phone at a local version of ccc but I haven't replicated the issue when running local ccc so far.

--- 

Separately, when enabling sentry logging locally by adding the DSN env var, the following was logged

> [Sentry] koa is not instrumented. This is likely because you required/imported koa before calling `Sentry.init()`.

