### PR TITLE
add support for testing a branch in docker

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -5,11 +5,13 @@ on:
   push:
     branches:
       - 'master'
+      - 'drew/fix-response-streams'
     tags:
       - 'v*'
   pull_request:
     branches:
       - 'master'
+      - 'drew/fix-response-streams'
 
 jobs:
   build:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,3 +26,13 @@ services:
       INSTITUTION: stolaf-college
     volumes:
       - ./.env:/app/.env:ro
+
+  stolaf-test:
+    image: frogpond/ccc-server:drew-fix-response-streams
+    restart: unless-stopped
+    environment:
+      INSTITUTION: stolaf-college
+    volumes:
+      - ./.env:/app/.env:ro
+    ports:
+      - '8080:80'


### PR DESCRIPTION
Running a branch in docker in a new container bound to a different port to help validate #901 (`drew/fix-response-streams`)