### PR TITLE
Update nginx configuration to match production

### DIFF
--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -61,7 +61,7 @@ proxy_set_header X-Forwarded-Ssl $proxy_x_forwarded_ssl;
 proxy_set_header X-Forwarded-Port $proxy_x_forwarded_port;
 
 # carleton.api.frogpond.tech
-upstream carleton.api.frogpond.tech {
+upstream carleton-backend {
   server carleton:80;
 }
 
@@ -69,7 +69,7 @@ server {
   server_name carleton.api.frogpond.tech;
 
   location / {
-    proxy_pass http://carleton.api.frogpond.tech;
+    proxy_pass http://carleton_backend;
   }
 
   listen 80;
@@ -81,11 +81,11 @@ server {
   access_log /var/log/nginx/access.log vhost;
 
   include "/etc/nginx/conf.d/ciphers/moz-modern.conf";
-  include "/etc/nginx/conf.d/ssl/api-frogpond-tech.conf";
+  include "/etc/nginx/conf.d/ssl/frogpond-tech.conf";
 }
 
 # stolaf.api.frogpond.tech
-upstream stolaf.api.frogpond.tech {
+upstream stolaf-backend {
   server stolaf:80;
 }
 
@@ -93,7 +93,7 @@ server {
   server_name stolaf.api.frogpond.tech;
 
   location / {
-    proxy_pass http://stolaf.api.frogpond.tech;
+    proxy_pass http://stolaf-backend;
   }
 
   listen 80;
@@ -105,7 +105,7 @@ server {
   access_log /var/log/nginx/access.log vhost;
 
   include "/etc/nginx/conf.d/ciphers/moz-modern.conf";
-  include "/etc/nginx/conf.d/ssl/api-frogpond-tech.conf";
+  include "/etc/nginx/conf.d/ssl/frogpond-tech.conf";
 }
 
 server {

--- a/nginx/ssl/frogpond-tech.conf
+++ b/nginx/ssl/frogpond-tech.conf
@@ -3,11 +3,11 @@ ssl_session_timeout 5m;
 ssl_session_cache shared:SSL:50m;
 ssl_session_tickets off;
 
-ssl_certificate /etc/letsencrypt/live/api.frogpond.tech/fullchain.pem;
-ssl_certificate_key /etc/letsencrypt/live/api.frogpond.tech/privkey.pem;
+ssl_certificate /etc/letsencrypt/live/frogpond.tech/fullchain.pem;
+ssl_certificate_key /etc/letsencrypt/live/frogpond.tech/privkey.pem;
 
 ssl_stapling on;
 ssl_stapling_verify on;
-ssl_trusted_certificate /etc/letsencrypt/live/api.frogpond.tech/fullchain.pem;
+ssl_trusted_certificate /etc/letsencrypt/live/frogpond.tech/fullchain.pem;
 
 add_header Strict-Transport-Security "max-age=2419200; includeSubDomains" always;


### PR DESCRIPTION
In preparation for a potential move to a new droplet, the nginx configuration should probably match what it is in the real world.

So, this PR updates the nginx configuration to match what is as deployed in the production droplet. Of note, we have both api.frogpond.tech and frogpond.tech under the same SSL certificate now where previously (2018) they were deployed under separate certificates.