### PR TITLE
sentry: Only log warn- and error-level messages to Sentry

### DIFF
--- a/source/ccc-server/index.ts
+++ b/source/ccc-server/index.ts
@@ -15,7 +15,10 @@ function setupSentry() {
 	Sentry.init({
 		dsn,
 		environment,
-		integrations: [nodeProfilingIntegration(), captureConsoleIntegration()],
+		integrations: [
+			nodeProfilingIntegration(),
+			captureConsoleIntegration({levels: ['warn', 'error']}),
+		],
 		// Performance Monitoring
 		tracesSampleRate: 1.0,
 		profilesSampleRate: 1.0,


### PR DESCRIPTION
The captureConsoleIntegration intercepts console messages and sends them to Sentry. By default, it sends all messages. This commit changes the set to just those levels that we probably care about and would have to go digging for otherwise.

Of note, we do use Sentry.setupKoaErrorHandler() in server.ts, which should negate the need for console.warn and console.error logs to be sent anyways. But, this should drastically reduce the number of alerts we get.