### PR TITLE
add search to streams endpoint

### DIFF
--- a/source/ccci-stolaf-college/v1/index.ts
+++ b/source/ccci-stolaf-college/v1/index.ts
@@ -113,6 +113,7 @@ api.get('/transit/modes', transit.modes)
 // streams
 api.get('/streams/archived', streams.archived)
 api.get('/streams/upcoming', streams.upcoming)
+api.get('/streams/search', streams.search)
 
 // stoprint
 api.get('/printing/color-printers', printing.colorPrinters)

--- a/source/ccci-stolaf-college/v1/streams.ts
+++ b/source/ccci-stolaf-college/v1/streams.ts
@@ -31,6 +31,7 @@ const GetStreamsParamsSchema = z.object({
 	dateFrom: z.string().date().optional(),
 	dateTo: z.string().date().optional(),
 	sort: z.enum(['ascending', 'descending']).default('ascending'),
+	query: z.string().optional(),
 })
 
 type StOlafStreamsParamsType = z.infer<typeof StOlafStreamsParamsSchema>
@@ -39,10 +40,11 @@ const StOlafStreamsParamsSchema = z.object({
 	date_to: z.string().date(),
 	sort: z.enum(['ascending', 'descending']),
 	class: z.enum(['current', 'archived']),
+	squery: z.string().optional(),
 })
 
 const getStreams = mem(
-	async (params: StOlafStreamsParamsType) => {
+	async (params: StOlafStreamsParamsType & { squery?: string }) => {
 		const url = 'https://www.stolaf.edu/multimedia/api/collection'
 		const response = await get(url, {searchParams: params})
 		const json = (await response.clone().json()) as Promise<
@@ -92,5 +94,24 @@ export async function archived(ctx: Context) {
 		date_from: dateFrom,
 		date_to: dateTo,
 		sort,
+	})
+}
+
+export async function search(ctx: Context) {
+	ctx.cacheControl(ONE_HOUR)
+
+	const {
+		dateFrom = moment().subtract(30, 'year').tz('America/Chicago').format('YYYY-MM-DD'),
+		dateTo = moment().tz('America/Chicago').format('YYYY-MM-DD'),
+		sort,
+		query,
+	} = GetStreamsParamsSchema.parse(Object.fromEntries(ctx.URL.searchParams.entries()))
+
+	ctx.body = await getStreams({
+		class: 'archived',
+		date_from: dateFrom,
+		date_to: dateTo,
+		sort,
+		...(query ? { squery: query } : {}),
 	})
 }


### PR DESCRIPTION
- Allow for searching of the archived streams
- Heuristic is last 30 years but this is open to change

> [!NOTE]  
> A client may want to pass in a custom date range, category, class (all/archived/upcoming), sort, offset in the future, though, but this does not have support for that