### PR TITLE
exclude codeowners due to dependabot

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,5 @@
 *	@drewvolz @hawkrives kristofer.rye@gmail.com
+
+# Exclude from automatic review due to dependabot
+package.json
+package-lock.json


### PR DESCRIPTION
PRs only targeting dependencies should no longer tag us by dependabot 🤞