### PR TITLE
remove dependabot config file

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,0 @@
-version: 2
-updates:
-  - package-ecosystem: npm
-    directory: '/'
-    schedule:
-      interval: daily
-    open-pull-requests-limit: 100
-    commit-message: {prefix: ''}


### PR DESCRIPTION
I think this might *actually* disable Dependabot.

because obviously the GUI settings don't do it…

<img width="1616" height="990" alt="image" src="https://github.com/user-attachments/assets/8efadc99-12f3-4db2-b737-bba3bf86d017" />

<img width="1236" height="914" alt="image" src="https://github.com/user-attachments/assets/19397195-0226-4c31-8b62-f9f754d312bc" />
