### PR TITLE
increase timeout on bonapp tests

### DIFF
--- a/source/ccci-carleton-college/v1/menu.test.ts
+++ b/source/ccci-carleton-college/v1/menu.test.ts
@@ -31,13 +31,17 @@ const cafeMenuFunctions: Record<keyof typeof menu.CAFE_URLS, (c: Context) => Pro
 } as const
 
 for (const cafe of keysOf(menu.CAFE_URLS)) {
-	test(`${cafe} cafe endpoint should return a BamcoCafeInfo struct`, async () => {
-		const ctx = {cacheControl: noop, body: null} as Context
-		await cafeInfoFunctions[cafe](ctx)
-		expect(() => CafeInfoResponseSchema.parse(ctx.body)).not.toThrow()
-	})
+	test(
+		`${cafe} cafe endpoint should return a BamcoCafeInfo struct`,
+		{timeout: 15_000},
+		async () => {
+			const ctx = {cacheControl: noop, body: null} as Context
+			await cafeInfoFunctions[cafe](ctx)
+			expect(() => CafeInfoResponseSchema.parse(ctx.body)).not.toThrow()
+		},
+	)
 
-	test(`${cafe} menu endpoint should return a CafeMenu struct`, async () => {
+	test(`${cafe} menu endpoint should return a CafeMenu struct`, {timeout: 15_000}, async () => {
 		const ctx = {cacheControl: noop, body: null} as Context
 		await cafeMenuFunctions[cafe](ctx)
 		expect(() => CafeMenuResponseSchema.parse(ctx.body)).not.toThrow()

--- a/source/ccci-stolaf-college/v1/menu.test.ts
+++ b/source/ccci-stolaf-college/v1/menu.test.ts
@@ -31,13 +31,17 @@ const cafeMenuFunctions: Record<keyof typeof menu.CAFE_URLS, (c: Context) => Pro
 } as const
 
 for (const cafe of keysOf(menu.CAFE_URLS)) {
-	test(`${cafe} cafe endpoint should return a BamcoCafeInfo struct`, async () => {
-		const ctx = {cacheControl: noop, body: null} as Context
-		await cafeInfoFunctions[cafe](ctx)
-		expect(() => CafeInfoResponseSchema.parse(ctx.body)).not.toThrow()
-	})
+	test(
+		`${cafe} cafe endpoint should return a BamcoCafeInfo struct`,
+		{timeout: 15_000},
+		async () => {
+			const ctx = {cacheControl: noop, body: null} as Context
+			await cafeInfoFunctions[cafe](ctx)
+			expect(() => CafeInfoResponseSchema.parse(ctx.body)).not.toThrow()
+		},
+	)
 
-	test(`${cafe} menu endpoint should return a CafeMenu struct`, async () => {
+	test(`${cafe} menu endpoint should return a CafeMenu struct`, {timeout: 15_000}, async () => {
 		const ctx = {cacheControl: noop, body: null} as Context
 		await cafeMenuFunctions[cafe](ctx)
 		expect(() => CafeMenuResponseSchema.parse(ctx.body)).not.toThrow()

--- a/source/menus-bonapp/index.test.ts
+++ b/source/menus-bonapp/index.test.ts
@@ -5,20 +5,28 @@ import {CafeInfoResponseSchema, CafeMenuResponseSchema} from './types.js'
 
 const STAV = 'https://stolaf.cafebonappetit.com/cafe/stav-hall/'
 
-test('fetching cafe info should not throw', async () => {
+test('fetching cafe info should not throw', {timeout: 15_000}, async () => {
 	await expect(bonApp._cafe(STAV)).resolves.not.toThrow()
 })
 
-test('fetching cafe info should return a CafeInfoResponseSchema struct', async () => {
-	const data = await bonApp._cafe(STAV)
-	expect(() => CafeInfoResponseSchema.parse(data)).not.toThrow()
-})
+test(
+	'fetching cafe info should return a CafeInfoResponseSchema struct',
+	{timeout: 15_000},
+	async () => {
+		const data = await bonApp._cafe(STAV)
+		expect(() => CafeInfoResponseSchema.parse(data)).not.toThrow()
+	},
+)
 
-test('fetching menu info should not throw', async () => {
+test('fetching menu info should not throw', {timeout: 15_000}, async () => {
 	await expect(bonApp._menu(STAV)).resolves.not.toThrow()
 })
 
-test('fetching menu info should return a CafeMenuResponseSchema struct', async () => {
-	const data = await bonApp._menu(STAV)
-	expect(() => CafeMenuResponseSchema.parse(data)).not.toThrow()
-})
+test(
+	'fetching menu info should return a CafeMenuResponseSchema struct',
+	{timeout: 15_000},
+	async () => {
+		const data = await bonApp._menu(STAV)
+		expect(() => CafeMenuResponseSchema.parse(data)).not.toThrow()
+	},
+)


### PR DESCRIPTION
They're often taking more than 5s to finish. Bump to 15s while we think about longer-term solutions.

I think Jest had a longer default timeout, which is why this only started occuring after we moved to Vitest in #937.