### PR TITLE
run workflows on all PRs, and on merge groups

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -15,7 +15,7 @@ on:
   push:
     branches: ['master']
   pull_request:
-    branches: ['master']
+  merge_group:
   schedule:
     - cron: '35 20 * * 0'
 

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -8,8 +8,7 @@ on:
     tags:
       - 'v*'
   pull_request:
-    branches:
-      - 'master'
+  merge_group:
 
 jobs:
   build:

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -7,7 +7,7 @@ on:
   push:
     branches: ['master']
   pull_request:
-    branches: ['master']
+  merge_group:
 
 jobs:
   # This job runs all the primary checks: linting, formatting, type checking, and unit tests.


### PR DESCRIPTION
because we kinda have to run them on merge queues in order to use merge queues