### PR TITLE
Update Renovate configuration to stop using semantic commit titles

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,8 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:best-practices"
+    "config:best-practices",
+    ":semanticCommitsDisabled"
   ],
   "prConcurrentLimit": 4,
   "reviewers": [],


### PR DESCRIPTION
They are a silly way to (attempt to) organize commits and not the convention in this repository.