### PR TITLE
Pin gh action digests, and add the full SemVer info to the comment

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,6 +2,7 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:best-practices",
+    "helpers:pinGitHubActionDigestsToSemver",
     ":semanticCommitsDisabled"
   ],
   "prConcurrentLimit": 4,


### PR DESCRIPTION
this is an upstream way of doing what I tried in https://github.com/frog-pond/ccc-server/pull/976/commits/68c3997dbfe08b2054f0d246660727b27e9f85fe 