### PR TITLE
Add copilot-setup-steps.yml for GitHub Copilot cloud environment

### DIFF
--- a/.config/mise.toml
+++ b/.config/mise.toml
@@ -43,9 +43,13 @@ run = "./scripts/smoke-test.sh carleton-college"
 [tasks.test]
 run = "node --test"
 
-[tasks.watch]
-depends = "build"                                # build once, before starting
-run = { tasks = ["build:watch", "start:watch"] }
+[tasks.build]
+run = "tsc --build ."
+env = { _.path = ['{{config_root}}/node_modules/.bin'] }
+
+[tasks."build:watch"]
+run = "tsc --watch --build ."
+env = { _.path = ['{{config_root}}/node_modules/.bin'] }
 
 [tasks.typecheck]
 run = "tsc --build ."

--- a/.config/mise.toml
+++ b/.config/mise.toml
@@ -48,7 +48,7 @@ run = "tsc --build ."
 env = { _.path = ['{{config_root}}/node_modules/.bin'] }
 
 [tasks."build:watch"]
-run = "tsc --watch --build ."
+run = "tsc --build --watch ."
 env = { _.path = ['{{config_root}}/node_modules/.bin'] }
 
 [tasks.typecheck]

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -16,7 +16,7 @@
 - **Preferred task runner:** This repo uses `mise` task definitions in `.config/mise.toml`. Use `mise run <task>` where possible; CI relies on these tasks.
 - **Install:** `npm install` (CI uses `npm ci` — you can run `mise run npm ci` in environments that support it)
 - **Development:**
-  - Watch/reload: `npm run watch` (see `scripts/watch.js`) or `mise run watch`
+  - Watch/reload: `npm run watch` (runs both TypeScript compilation and server in watch mode) or use `mise run build:watch` + `mise run start:watch` in separate terminals
   - Institution-specific dev: `mise run stolaf-college` or `mise run carleton-college` (these set `INSTITUTION` and depend on `build`)
 - **Build:** `mise run build` (same as `npm run build`)
 - **Production:** `mise run start:prod` (or `npm run start:prod`)

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -29,14 +29,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      - name: Set up Node.js
-        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
-        with:
-          node-version: '24.11.0'
-          cache: 'npm'
+      - name: Setup mise
+        uses: jdx/mise-action@e3d7b8d67a7958d1207f6ed871e83b1ea780e7b0 # v3.3.1
 
       - name: Install dependencies
         run: npm ci
 
-      - name: Build TypeScript
-        run: npm run build
+      - name: Type check and build
+        run: mise run typecheck

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -30,7 +30,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Set up Node.js
-        uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44844de19 # v4.2.0
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version: '24.11.0'
           cache: 'npm'

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -27,10 +27,10 @@ jobs:
     # If you do not check out your code, Copilot will do this for you.
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44844de19 # v4.2.0
         with:
           node-version: '24.11.0'
           cache: 'npm'

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -1,0 +1,42 @@
+name: 'Copilot Setup Steps'
+
+# Automatically run the setup steps when they are changed to allow for easy validation, and
+# allow manual testing through the repository's "Actions" tab
+on:
+  workflow_dispatch:
+  push:
+    branches: [master]
+    paths:
+      - .github/workflows/copilot-setup-steps.yml
+  pull_request:
+    paths:
+      - .github/workflows/copilot-setup-steps.yml
+
+jobs:
+  # The job MUST be called `copilot-setup-steps` or it will not be picked up by Copilot.
+  copilot-setup-steps:
+    runs-on: ubuntu-latest
+
+    # Set the permissions to the lowest permissions possible needed for your steps.
+    # Copilot will be given its own token for its operations.
+    permissions:
+      # If you want to clone the repository as part of your setup steps, for example to install dependencies, you'll need the `contents: read` permission. If you don't clone the repository in your setup steps, Copilot will do this for you automatically after the steps complete.
+      contents: read
+
+    # You can define any steps you want, and they will run before the agent starts.
+    # If you do not check out your code, Copilot will do this for you.
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24.11.0'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build TypeScript
+        run: npm run build

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ cautious-computing-context: backend node caching server/proxy
 ## Getting Started
 
 Prerequisites
-- Node.js v20.17
+- Node.js v24.11.0
 - npm
 
 Install
@@ -22,8 +22,14 @@ npm ci
 
 Watch mode (recommended): auto-recompile & restart on changes
 
+Run these in separate terminals:
+
 ```sh
-mise run watch
+# TypeScript compilation in watch mode
+mise run build:watch
+
+# Server with auto-restart
+mise run start:watch
 ```
 
 Institution-specific servers


### PR DESCRIPTION
This PR adds a `copilot-setup-steps.yml` workflow file to configure GitHub Copilot's cloud development environment.

## Copilot Setup Changes
- Added `.github/workflows/copilot-setup-steps.yml` with setup steps for the Copilot coding agent
- Use mise for Node.js setup (installs Node 24.11.0 per mise.toml, consistent with CI)
- Install npm dependencies
- Run `mise run typecheck` for TypeScript compilation and validation

## Mise Configuration Fixes
Fixed broken mise task dependencies:
- Added missing `[tasks.build]` - runs `tsc --build .` (matches `npm run build`)
- Added missing `[tasks.build:watch]` - runs `tsc --build --watch .` (matches `npm run build:watch`)
- Removed broken `[tasks.watch]` which was referencing non-existent tasks
- Kept `[tasks.typecheck]` for semantic distinction (validation context vs build context)

## Documentation Updates
Updated README.md:
- Fixed Node.js prerequisite from v20.17 to v24.11.0 (matching mise.toml)
- Replaced broken `mise run watch` with working watch commands
- Documented `mise run build:watch` and `mise run start:watch` for development

Updated .github/copilot-instructions.md:
- Fixed watch command reference (removed non-existent scripts/watch.js)
- Updated to reflect current working watch commands

## Why
GitHub Copilot can now run this repository in the cloud with proper environment setup. The workflow automatically runs when the file is modified to validate it works correctly.

## Documentation
See: https://docs.github.com/en/copilot/how-tos/use-copilot-agents/coding-agent/customize-the-agent-environment