### PR TITLE
athletics endpoints

### DIFF
--- a/source/athletics/index.ts
+++ b/source/athletics/index.ts
@@ -1,0 +1,70 @@
+import {z} from 'zod'
+import {getJson} from '../ccc-lib/http.ts'
+
+// ── Zod schemas ──────────────────────────────────────────────────────────────
+
+const LocationInfoSchema = z.object({
+	location: z.string(),
+	HAN: z.enum(['H', 'A', 'N']),
+	facility: z.string(),
+})
+
+const StatusInfoSchema = z.object({
+	indicator: z.enum(['O', 'A']),
+	value: z.string(),
+})
+
+const LinkSchema = z.object({
+	url: z.string(),
+	text: z.string(),
+})
+
+const LinksSchema = z
+	.object({
+		postgame: LinkSchema.optional(),
+		boxscore: LinkSchema.optional(),
+		livestats: LinkSchema.optional(),
+		streaming_video: LinkSchema.optional(),
+	})
+	.catchall(z.unknown())
+
+export const ScoreSchema = z.object({
+	id: z.string(),
+	sport: z.string(),
+	sport_abbrev: z.string(),
+	date: z.string(),
+	dateFormatted: z.string(),
+	date_utc: z.string(),
+	date_end_utc: z.string(),
+	time: z.string(),
+	timestamp: z.number(),
+	location: LocationInfoSchema,
+	status: StatusInfoSchema,
+	hometeam: z.string(),
+	hometeam_logo: z.string(),
+	opponent: z.string(),
+	opponent_logo: z.string(),
+	team_score: z.string(),
+	opponent_score: z.string(),
+	result: z.enum(['W', 'L', 'N', '']),
+	ip_time: z.string(),
+	prescore_info: z.string(),
+	postscore_info: z.string(),
+	links: LinksSchema,
+	coverage: z.record(z.unknown()),
+})
+
+export type Score = z.infer<typeof ScoreSchema>
+
+const AthleticsResponseSchema = z.object({
+	timestamp: z.unknown(),
+	status: z.unknown(),
+	scores: z.array(ScoreSchema),
+})
+
+// ── Fetch ────────────────────────────────────────────────────────────────────
+
+export async function fetchAthleticsScores(url: string): Promise<Score[]> {
+	const response = AthleticsResponseSchema.parse(await getJson(url))
+	return response.scores
+}

--- a/source/athletics/index.ts
+++ b/source/athletics/index.ts
@@ -28,14 +28,33 @@ const LinksSchema = z
 	})
 	.catchall(z.unknown())
 
+/**
+ * Parses the upstream API's non-standard "M/D/YYYY h:mm:ss AM/PM" UTC format
+ * and returns an ISO 8601 string so consumers can use new Date() safely.
+ */
+function parseDateUtcField(dateStr: string): string {
+	const parts = dateStr.split(' ')
+	if (parts.length !== 3) {
+		return dateStr
+	}
+	const [datePart, timePart, ampm] = parts as [string, string, string]
+	const [month, day, year] = datePart.split('/').map(Number) as [number, number, number]
+	const [hours, minutes, seconds] = timePart.split(':').map(Number) as [number, number, number]
+	let hour24 = hours % 12
+	if (ampm === 'PM') {
+		hour24 += 12
+	}
+	return new Date(Date.UTC(year, month - 1, day, hour24, minutes, seconds)).toISOString()
+}
+
 export const ScoreSchema = z.object({
 	id: z.string(),
 	sport: z.string(),
 	sport_abbrev: z.string(),
 	date: z.string(),
 	dateFormatted: z.string(),
-	date_utc: z.string(),
-	date_end_utc: z.string(),
+	date_utc: z.string().transform(parseDateUtcField),
+	date_end_utc: z.string().transform(parseDateUtcField),
 	time: z.string(),
 	timestamp: z.number(),
 	location: LocationInfoSchema,

--- a/source/athletics/index.ts
+++ b/source/athletics/index.ts
@@ -5,7 +5,7 @@ import {getJson} from '../ccc-lib/http.ts'
 
 const LocationInfoSchema = z.object({
 	location: z.string(),
-	HAN: z.enum(['H', 'A', 'N']),
+	homeAway: z.enum(['H', 'A', 'N']),
 	facility: z.string(),
 })
 

--- a/source/ccci-carleton-college/v1/athletics.ts
+++ b/source/ccci-carleton-college/v1/athletics.ts
@@ -3,7 +3,7 @@ import {ONE_MINUTE} from '../../ccc-lib/constants.ts'
 import type {Context} from '../../ccc-server/context.ts'
 
 const ATHLETICS_URL =
-	'https://athletics.stolaf.edu/services/scores_chris.aspx?format=json'
+	'https://athletics.carleton.edu/services/scores_chris.aspx?format=json'
 
 const FIVE_MINUTES = ONE_MINUTE * 5
 

--- a/source/ccci-carleton-college/v1/athletics.ts
+++ b/source/ccci-carleton-college/v1/athletics.ts
@@ -2,8 +2,7 @@ import {fetchAthleticsScores} from '../../athletics/index.ts'
 import {ONE_MINUTE} from '../../ccc-lib/constants.ts'
 import type {Context} from '../../ccc-server/context.ts'
 
-const ATHLETICS_URL =
-	'https://athletics.carleton.edu/services/scores_chris.aspx?format=json'
+const ATHLETICS_URL = 'https://athletics.carleton.edu/services/scores_chris.aspx?format=json'
 
 const FIVE_MINUTES = ONE_MINUTE * 5
 

--- a/source/ccci-carleton-college/v1/index.ts
+++ b/source/ccci-carleton-college/v1/index.ts
@@ -1,4 +1,5 @@
 import Router from '@koa/router'
+import * as athletics from './athletics.ts'
 import * as calendar from './calendar.ts'
 import * as contacts from './contacts.ts'
 import * as convos from './convos.ts'
@@ -112,6 +113,9 @@ api.get('/transit/modes', transit.modes)
 
 // utilities
 api.get('/util/html-to-md', util.htmlToMarkdown)
+
+// athletics
+api.get('/athletics/scores', athletics.scores)
 
 // sitemap
 api.get('/routes', (ctx: Context) => {

--- a/source/ccci-stolaf-college/v1/athletics.ts
+++ b/source/ccci-stolaf-college/v1/athletics.ts
@@ -1,0 +1,86 @@
+import {z} from 'zod'
+import {getJson} from '../../ccc-lib/http.ts'
+import {ONE_MINUTE} from '../../ccc-lib/constants.ts'
+import type {Context} from '../../ccc-server/context.ts'
+
+const ATHLETICS_URL =
+	'https://athletics.stolaf.edu/services/scores_chris.aspx?format=json'
+
+const FIVE_MINUTES = ONE_MINUTE * 5
+
+// ── Zod schemas ──────────────────────────────────────────────────────────────
+
+const LocationInfoSchema = z.object({
+	location: z.string(),
+	HAN: z.enum(['H', 'A', 'N']),
+	facility: z.string(),
+})
+
+const StatusInfoSchema = z.object({
+	indicator: z.enum(['O', 'A']),
+	value: z.string(),
+})
+
+const LinkSchema = z.object({
+	url: z.string(),
+	text: z.string(),
+})
+
+const LinksSchema = z
+	.object({
+		postgame: LinkSchema.optional(),
+		boxscore: LinkSchema.optional(),
+		livestats: LinkSchema.optional(),
+		streaming_video: LinkSchema.optional(),
+	})
+	.catchall(z.unknown())
+
+const ScoreSchema = z.object({
+	id: z.string(),
+	sport: z.string(),
+	sport_abbrev: z.string(),
+	date: z.string(),
+	dateFormatted: z.string(),
+	date_utc: z.string(),
+	date_end_utc: z.string(),
+	time: z.string(),
+	timestamp: z.number(),
+	location: LocationInfoSchema,
+	status: StatusInfoSchema,
+	hometeam: z.string(),
+	hometeam_logo: z.string(),
+	opponent: z.string(),
+	opponent_logo: z.string(),
+	team_score: z.string(),
+	opponent_score: z.string(),
+	result: z.enum(['W', 'L', 'N', '']),
+	ip_time: z.string(),
+	prescore_info: z.string(),
+	postscore_info: z.string(),
+	links: LinksSchema,
+	coverage: z.record(z.unknown()),
+})
+
+const AthleticsResponseSchema = z.object({
+	timestamp: z.unknown(),
+	status: z.unknown(),
+	scores: z.array(ScoreSchema),
+})
+
+export type Score = z.infer<typeof ScoreSchema>
+
+// ── Fetch ────────────────────────────────────────────────────────────────────
+
+async function fetchAthleticsScores(): Promise<Score[]> {
+	const response = AthleticsResponseSchema.parse(await getJson(ATHLETICS_URL))
+	return response.scores
+}
+
+// ── Handler ──────────────────────────────────────────────────────────────────
+
+export async function scores(ctx: Context) {
+	ctx.cacheControl(FIVE_MINUTES)
+	if (ctx.cached(FIVE_MINUTES)) return
+
+	ctx.body = await fetchAthleticsScores()
+}

--- a/source/ccci-stolaf-college/v1/athletics.ts
+++ b/source/ccci-stolaf-college/v1/athletics.ts
@@ -2,8 +2,7 @@ import {fetchAthleticsScores} from '../../athletics/index.ts'
 import {ONE_MINUTE} from '../../ccc-lib/constants.ts'
 import type {Context} from '../../ccc-server/context.ts'
 
-const ATHLETICS_URL =
-	'https://athletics.stolaf.edu/services/scores_chris.aspx?format=json'
+const ATHLETICS_URL = 'https://athletics.stolaf.edu/services/scores_chris.aspx?format=json'
 
 const FIVE_MINUTES = ONE_MINUTE * 5
 

--- a/source/ccci-stolaf-college/v1/index.ts
+++ b/source/ccci-stolaf-college/v1/index.ts
@@ -1,4 +1,5 @@
 import Router from '@koa/router'
+import * as athletics from './athletics.ts'
 import * as atoz from './a-z.ts'
 import * as calendar from './calendar.ts'
 import * as contacts from './contacts.ts'
@@ -122,6 +123,9 @@ api.get('/reports/stav', reports.stavMealtimeReport)
 
 // utilities
 api.get('/util/html-to-md', util.htmlToMarkdown)
+
+// athletics
+api.get('/athletics/scores', athletics.scores)
 
 // sitemap
 api.get('/routes', (ctx: Context) => {


### PR DESCRIPTION
This pull request adds a new athletics scores endpoint for both Carleton and St. Olaf APIs, providing a way to fetch and serve athletics scores from each college's athletics site.

**New Athletics Scores Fetching and Validation**

* Introduced `fetchAthleticsScores` in `source/athletics/index.ts`, which defines Zod schemas for validating and parsing athletics scores data, and provides a reusable fetch function for both colleges.

**Carleton API Integration**

* Added `source/ccci-carleton-college/v1/athletics.ts` to implement the `/athletics/scores` endpoint, using the shared fetcher and setting a 5-minute cache.
* Registered the new endpoint in the Carleton API router in `source/ccci-carleton-college/v1/index.ts`.

**St. Olaf API Integration**

* Added `source/ccci-stolaf-college/v1/athletics.ts` to implement the `/athletics/scores` endpoint, mirroring the Carleton setup with the appropriate URL and caching.
* Registered the new endpoint in the St. Olaf API router in `source/ccci-stolaf-college/v1/index.ts`.