### PR TITLE
scope node --test to source/ to avoid stale dist/ files

### DIFF
--- a/.config/mise.toml
+++ b/.config/mise.toml
@@ -41,7 +41,7 @@ run = "./scripts/smoke-test.sh stolaf-college"
 run = "./scripts/smoke-test.sh carleton-college"
 
 [tasks.test]
-run = "node --test"
+run = "node --test 'source/**/*.test.ts'"
 
 [tasks.build]
 run = "tsc --build ."

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "carleton-college": "env INSTITUTION=carleton-college npm run start:dev",
     "test:stolaf-college": "./scripts/smoke-test.sh stolaf-college",
     "test:carleton-college": "./scripts/smoke-test.sh carleton-college",
-    "test": "node --test",
+    "test": "node --test 'source/**/*.test.ts'",
     "watch": "npm run build:watch & npm run start:watch"
   },
   "dependencies": {


### PR DESCRIPTION
## Problem

`node --test` without a glob recursively discovers all `*.test.{js,ts}` files, including stale vitest-era compiled files in `dist/`. These old files still `import from 'vitest'`, causing 4 test failures:

- `dist/source/calendar/ical.test.js`
- `dist/source/ccci-carleton-college/v1/menu.test.js`
- `dist/source/ccci-stolaf-college/v1/menu.test.js`
- `dist/source/menus-bonapp/index.test.js`

## Fix

Scope the test command to `source/**/*.test.ts` in both `mise.toml` and `package.json`. Since Node 24 runs TypeScript directly, no compiled output is needed.

## Impact

- `mise run test` / `npm test` now only runs source test files
- `mise run check` passes cleanly on master after this lands