### PR TITLE
advertise ccc-server via mDNS in dev mode

### DIFF
--- a/.config/mise.toml
+++ b/.config/mise.toml
@@ -30,9 +30,17 @@ env = { NODE_ENV = "production" }
 run = "mise run start"
 env = { INSTITUTION = "stolaf-college" }
 
+[tasks."stolaf-college:mdns"]
+run = "mise run start"
+env = { INSTITUTION = "stolaf-college", ADVERTISE_MDNS = "1" }
+
 [tasks."carleton-college"]
 run = "mise run start"
 env = { INSTITUTION = "carleton-college" }
+
+[tasks."carleton-college:mdns"]
+run = "mise run start"
+env = { INSTITUTION = "carleton-college", ADVERTISE_MDNS = "1" }
 
 [tasks."test:stolaf-college"]
 run = "./scripts/smoke-test.sh stolaf-college"

--- a/README.md
+++ b/README.md
@@ -39,6 +39,29 @@ mise run stolaf-college
 mise run carleton-college
 ```
 
+### Local Network Discovery (mDNS)
+
+When developing alongside a React Native client on the same network, you can advertise the server via mDNS/Bonjour so the client can discover it automatically without typing the IP address.
+
+```sh
+mise run stolaf-college:mdns
+mise run carleton-college:mdns
+```
+
+This publishes a `_ccc-server._tcp` service (via `dns-sd` on macOS, `bonjour-service` elsewhere). The service name includes the hostname (e.g. `ccc-server (Gecko)`), and the TXT record contains the institution name and the `/v1/` path prefix. The advertisement is torn down cleanly on `SIGTERM`/`SIGINT`.
+
+You can also set `ADVERTISE_MDNS=1` manually alongside any start command:
+
+```sh
+ADVERTISE_MDNS=1 mise run stolaf-college
+```
+
+To verify the advertisement is visible on the network:
+
+```sh
+dns-sd -B _ccc-server._tcp local
+```
+
 ### Production
 
 ```sh

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@sentry/node": "10.21.0",
         "@sentry/profiling-node": "10.21.0",
         "@sentry/utils": "8.55.0",
+        "bonjour-service": "^1.3.0",
         "dotenv": "^17.0.0",
         "get-urls": "12.1.0",
         "html-entities": "2.6.0",
@@ -566,6 +567,12 @@
       "engines": {
         "node": ">= 20"
       }
+    },
+    "node_modules/@leichtgewicht/ip-codec": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.5.tgz",
+      "integrity": "sha512-Vo+PSpZG2/fmgmiNzYK9qWRh8h/CHrwD0mo1h1DzL4yzHNSfWYujGTYsWGreD000gcgmZ7K4Ys6Tx9TxtsKdDw==",
+      "license": "MIT"
     },
     "node_modules/@mixmark-io/domino": {
       "version": "2.2.0",
@@ -1988,6 +1995,16 @@
         "require-from-string": "^2.0.2"
       }
     },
+    "node_modules/bonjour-service": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/bonjour-service/-/bonjour-service-1.3.0.tgz",
+      "integrity": "sha512-3YuAUiSkWykd+2Azjgyxei8OWf8thdn8AITIog2M4UICzoqfjlqr64WIjEXZllf/W6vK1goqleSR6brGomxQqA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "multicast-dns": "^7.2.5"
+      }
+    },
     "node_modules/brace-expansion": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
@@ -2275,6 +2292,18 @@
         "node": ">=8"
       }
     },
+    "node_modules/dns-packet": {
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-5.6.1.tgz",
+      "integrity": "sha512-l4gcSouhcgIKRvyy99RNVOgxXiicE+2jZoNmaNmZ6JXiGajBOJAesk1OBlJuM5k2c+eudGdLxDqXuPCKIj6kpw==",
+      "license": "MIT",
+      "dependencies": {
+        "@leichtgewicht/ip-codec": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/dotenv": {
       "version": "17.4.2",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
@@ -2534,7 +2563,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-json-stable-stringify": {
@@ -3365,6 +3393,19 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
+    "node_modules/multicast-dns": {
+      "version": "7.2.5",
+      "resolved": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-7.2.5.tgz",
+      "integrity": "sha512-2eznPJP8z2BFLX50tf0LuODrpINqP1RVIm/CObbTcBRITQgmC/TjcREF1NeTBzIcR5XO/ukWo+YHOjBbFwIupg==",
+      "license": "MIT",
+      "dependencies": {
+        "dns-packet": "^5.2.2",
+        "thunky": "^1.0.2"
+      },
+      "bin": {
+        "multicast-dns": "cli.js"
+      }
+    },
     "node_modules/natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -3900,6 +3941,12 @@
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "license": "MIT"
+    },
+    "node_modules/thunky": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/thunky/-/thunky-1.1.0.tgz",
+      "integrity": "sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA==",
       "license": "MIT"
     },
     "node_modules/time-span": {

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "@sentry/node": "10.21.0",
     "@sentry/profiling-node": "10.21.0",
     "@sentry/utils": "8.55.0",
+    "bonjour-service": "^1.3.0",
     "dotenv": "^17.0.0",
     "get-urls": "12.1.0",
     "html-entities": "2.6.0",

--- a/source/ccc-server/server.ts
+++ b/source/ccc-server/server.ts
@@ -140,13 +140,58 @@ async function main() {
 
 	// eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
 	const PORT = process.env['NODE_PORT'] || '3000'
-	const port = Number.parseInt(PORT, 10)
-	app.listen(port)
-	console.log(`listening on port ${PORT}`)
+	const parsedPort = Number.parseInt(PORT, 10)
+	if (!Number.isInteger(parsedPort) || parsedPort < 0 || parsedPort > 65_535) {
+		console.error(`NODE_PORT must be an integer between 0 and 65535, but got: ${PORT}`)
+		process.exit(1)
+	}
+
+	const server = app.listen(parsedPort)
+	await new Promise<void>((resolve, reject) => {
+		server.once('listening', resolve)
+		server.once('error', reject)
+	})
+
+	let boundAddress = server.address()
+	if (boundAddress === null || typeof boundAddress === 'string') {
+		console.error('failed to determine bound server address')
+		process.exit(1)
+	}
+	const boundPort = boundAddress.port
+	console.log(`listening on port ${String(boundPort)}`)
 
 	if (process.env['ADVERTISE_MDNS'] === '1') {
 		const {hostname} = await import('node:os')
 		const serviceName = `ccc-server (${hostname()})`
+		let shutdownInitiated = false
+		let stopAdvertisement: (() => void | Promise<void>) | undefined
+		const closeServer = () =>
+			new Promise<void>((resolve) => {
+				server.close(() => {
+					resolve()
+				})
+			})
+		const installShutdownHandlers = () => {
+			const handleSignal = (signal: NodeJS.Signals) => {
+				if (shutdownInitiated) return
+				shutdownInitiated = true
+				void (async () => {
+					await stopAdvertisement?.()
+					await closeServer()
+					process.removeListener('SIGTERM', onSigTerm)
+					process.removeListener('SIGINT', onSigInt)
+					process.kill(process.pid, signal)
+				})()
+			}
+			const onSigTerm = () => {
+				handleSignal('SIGTERM')
+			}
+			const onSigInt = () => {
+				handleSignal('SIGINT')
+			}
+			process.once('SIGTERM', onSigTerm)
+			process.once('SIGINT', onSigInt)
+		}
 
 		if (process.platform === 'darwin') {
 			// On macOS, delegate to dns-sd so registration goes through the system
@@ -160,40 +205,59 @@ async function main() {
 					serviceName,
 					'_ccc-server._tcp',
 					'local',
-					String(port),
+					String(boundPort),
 					`institution=${institution}`,
 					'path=/v1/',
 				],
 				{stdio: 'ignore', detached: false},
 			)
-			console.log(
-				`advertising mDNS service: ${serviceName}._ccc-server._tcp on port ${String(port)}`,
-			)
-
-			const teardown = () => child.kill()
-			process.once('SIGTERM', teardown)
-			process.once('SIGINT', teardown)
-		} else {
-			const {Bonjour} = await import('bonjour-service')
-			const bonjour = new Bonjour()
-			const service = bonjour.publish({
-				name: serviceName,
-				type: 'ccc-server',
-				port,
-				txt: {institution, path: '/v1/'},
+			child.once('error', (error) => {
+				console.warn(`mDNS advertisement disabled: failed to start dns-sd (${error.message})`)
 			})
 			console.log(
-				`advertising mDNS service: ${service.name}._ccc-server._tcp on port ${String(port)}`,
+				`advertising mDNS service: ${serviceName}._ccc-server._tcp on port ${String(boundPort)}`,
 			)
 
-			const teardown = () => {
-				service.stop?.(() => {
-					// bonjour.destroy() returns any; call without returning
-					bonjour.destroy()
-				})
+			stopAdvertisement = () => {
+				child.kill()
 			}
-			process.once('SIGTERM', teardown)
-			process.once('SIGINT', teardown)
+			installShutdownHandlers()
+		} else {
+			try {
+				const {Bonjour} = await import('bonjour-service')
+				const bonjour = new Bonjour()
+				const service = bonjour.publish({
+					name: serviceName,
+					type: 'ccc-server',
+					port: boundPort,
+					txt: {institution, path: '/v1/'},
+				})
+				console.log(
+					`advertising mDNS service: ${service.name}._ccc-server._tcp on port ${String(boundPort)}`,
+				)
+
+				stopAdvertisement = () =>
+					new Promise<void>((resolve) => {
+						const stop =
+							typeof service.stop === 'function'
+								? (service.stop as (callback: () => void) => void)
+								: undefined
+						if (!stop) {
+							bonjour.destroy()
+							resolve()
+							return
+						}
+						stop(() => {
+							// bonjour.destroy() returns any; call without returning
+							bonjour.destroy()
+							resolve()
+						})
+					})
+				installShutdownHandlers()
+			} catch (error) {
+				const message = error instanceof Error ? error.message : String(error)
+				console.warn(`mDNS advertisement disabled: ${message}`)
+			}
 		}
 	}
 }

--- a/source/ccc-server/server.ts
+++ b/source/ccc-server/server.ts
@@ -155,10 +155,20 @@ async function main() {
 			const {spawn} = await import('node:child_process')
 			const child = spawn(
 				'dns-sd',
-				['-R', serviceName, '_ccc-server._tcp', 'local', String(port), `institution=${institution}`, 'path=/v1/'],
+				[
+					'-R',
+					serviceName,
+					'_ccc-server._tcp',
+					'local',
+					String(port),
+					`institution=${institution}`,
+					'path=/v1/',
+				],
 				{stdio: 'ignore', detached: false},
 			)
-			console.log(`advertising mDNS service: ${serviceName}._ccc-server._tcp on port ${String(port)}`)
+			console.log(
+				`advertising mDNS service: ${serviceName}._ccc-server._tcp on port ${String(port)}`,
+			)
 
 			const teardown = () => child.kill()
 			process.once('SIGTERM', teardown)
@@ -172,7 +182,9 @@ async function main() {
 				port,
 				txt: {institution, path: '/v1/'},
 			})
-			console.log(`advertising mDNS service: ${service.name}._ccc-server._tcp on port ${String(port)}`)
+			console.log(
+				`advertising mDNS service: ${service.name}._ccc-server._tcp on port ${String(port)}`,
+			)
 
 			const teardown = () => {
 				service.stop?.(() => {

--- a/source/ccc-server/server.ts
+++ b/source/ccc-server/server.ts
@@ -140,8 +140,50 @@ async function main() {
 
 	// eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
 	const PORT = process.env['NODE_PORT'] || '3000'
-	app.listen(Number.parseInt(PORT, 10))
+	const port = Number.parseInt(PORT, 10)
+	app.listen(port)
 	console.log(`listening on port ${PORT}`)
+
+	if (process.env['ADVERTISE_MDNS'] === '1') {
+		const {hostname} = await import('node:os')
+		const serviceName = `ccc-server (${hostname()})`
+
+		if (process.platform === 'darwin') {
+			// On macOS, delegate to dns-sd so registration goes through the system
+			// mDNSResponder. A pure-JS mDNS stack competing on port 5353 triggers
+			// Bonjour name-conflict dialogs and can rename the host.
+			const {spawn} = await import('node:child_process')
+			const child = spawn(
+				'dns-sd',
+				['-R', serviceName, '_ccc-server._tcp', 'local', String(port), `institution=${institution}`, 'path=/v1/'],
+				{stdio: 'ignore', detached: false},
+			)
+			console.log(`advertising mDNS service: ${serviceName}._ccc-server._tcp on port ${String(port)}`)
+
+			const teardown = () => child.kill()
+			process.once('SIGTERM', teardown)
+			process.once('SIGINT', teardown)
+		} else {
+			const {Bonjour} = await import('bonjour-service')
+			const bonjour = new Bonjour()
+			const service = bonjour.publish({
+				name: serviceName,
+				type: 'ccc-server',
+				port,
+				txt: {institution, path: '/v1/'},
+			})
+			console.log(`advertising mDNS service: ${service.name}._ccc-server._tcp on port ${String(port)}`)
+
+			const teardown = () => {
+				service.stop?.(() => {
+					// bonjour.destroy() returns any; call without returning
+					bonjour.destroy()
+				})
+			}
+			process.once('SIGTERM', teardown)
+			process.once('SIGINT', teardown)
+		}
+	}
 }
 
 await main()


### PR DESCRIPTION
## Summary

Adds opt-in mDNS/Bonjour advertisement so a React Native client on the same network can discover the server automatically, without manually typing an IP address.

## How it works

When started with `ADVERTISE_MDNS=1`, the server publishes a `_ccc-server._tcp` Bonjour service after binding. The TXT record carries `institution` and `path=/v1/` so clients know which server they're connecting to.

**Platform-specific advertisement:**
- **macOS**: delegates to `dns-sd -R` (registers through the system mDNSResponder). A pure-JS mDNS stack competing on port 5353 caused Bonjour name-conflict dialogs and renamed the host — this avoids that entirely.
- **Linux/other**: uses `bonjour-service` (pure-JS, appropriate since there's no competing mDNSResponder).

**Service type:** `_ccc-server._tcp` (private type, not `_http._tcp`) so clients don't need broad HTTP scanning permissions.

## Usage

```sh
# New mise tasks
mise run stolaf-college:mdns
mise run carleton-college:mdns

# Or manually
ADVERTISE_MDNS=1 mise run stolaf-college

# Verify advertisement is visible
dns-sd -B _ccc-server._tcp local
```

## Changes
- `source/ccc-server/server.ts`: mDNS advertisement logic, gated on `ADVERTISE_MDNS=1`
- `.config/mise.toml`: adds `:mdns` task variants
- `README.md`: documents the feature and usage
- `package.json`: adds `bonjour-service` dependency