### PR TITLE
disable http2 to mitigate HTTP/2 Bomb DoS vulnerability (CVE pending)

### DIFF
--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -75,8 +75,8 @@ server {
   listen 80;
   listen [::]:80;
 
-  listen 443 ssl http2;
-  listen [::]:443 ssl http2;
+  listen 443 ssl;
+  listen [::]:443 ssl;
 
   access_log /var/log/nginx/access.log vhost;
 
@@ -99,8 +99,8 @@ server {
   listen 80;
   listen [::]:80;
 
-  listen 443 ssl http2;
-  listen [::]:443 ssl http2;
+  listen 443 ssl;
+  listen [::]:443 ssl;
 
   access_log /var/log/nginx/access.log vhost;
 
@@ -112,8 +112,8 @@ server {
   listen 80 default_server;
   listen [::]:80 default_server;
 
-  # listen 443 ssl http2 default_server;
-  # listen [::]:443 ssl http2 default_server;
+  # listen 443 ssl default_server;
+  # listen [::]:443 ssl default_server;
   access_log /var/log/nginx/access.log vhost;
 
   server_name _; # This is just an invalid value which will never trigger on a real hostname.


### PR DESCRIPTION
pending upgrade to 1.29.8+ for nginx

https://thehackernews.com/2026/06/new-http2-bomb-vulnerability-allows.html